### PR TITLE
Update tun to 0.5.1

### DIFF
--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -190,7 +190,7 @@ warp = { version = "0.2", optional = true }
 
 # TUN
 [target.'cfg(any(target_os = "ios", target_os = "macos", target_os = "linux"))'.dependencies]
-tun = { git = "https://github.com/eycorsican/rust-tun.git", branch = "fix-endianness", features = ["async"], optional = true }
+tun = { version = "0.5.1", features = ["async"], optional = true }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Hi, I'm submitting leaf to Homebrew (Homebrew/homebrew-core#72070), and one of the dependencies `ioctl-sys` only builds on macOS ARM after version 0.6, which requires `tun` 0.5.1 (and the fork is no longer needed).

BTW, can I ask you if Rust nightly is needed for anything else than [Profile `strip` option](https://doc.rust-lang.org/cargo/reference/unstable.html#profile-strip-option)? If so, can you remove it from `Cargo.toml` so it build on stable Rust without modification? You can still enable the feature in the releases via `cargo build -Z strip=symbols`.