### PR TITLE
Fix potential undefined behavior in tun inbound

### DIFF
--- a/leaf/src/proxy/tun/netstack/mod.rs
+++ b/leaf/src/proxy/tun/netstack/mod.rs
@@ -5,6 +5,7 @@ mod stack_impl;
 mod tcp_listener;
 mod tcp_listener_impl;
 mod tcp_stream;
+mod tcp_stream_context;
 mod tcp_stream_impl;
 mod udp;
 mod util;

--- a/leaf/src/proxy/tun/netstack/stack_impl.rs
+++ b/leaf/src/proxy/tun/netstack/stack_impl.rs
@@ -50,9 +50,6 @@ pub struct NetStackImpl {
     fakedns: Arc<TokioMutex<FakeDns>>,
 }
 
-unsafe impl Sync for NetStackImpl {}
-unsafe impl Send for NetStackImpl {}
-
 impl NetStackImpl {
     pub fn new(
         inbound_tag: String,
@@ -346,6 +343,7 @@ impl AsyncWrite for NetStackImpl {
             if let Some(input_fn) = (*netif_list).input {
                 let err = input_fn(pbuf, netif_list);
                 if err == err_enum_t_ERR_OK as err_t {
+                    trace!("Input packet {}", buf.len());
                     Poll::Ready(Ok(buf.len()))
                 } else {
                     pbuf_free(pbuf);

--- a/leaf/src/proxy/tun/netstack/stack_impl.rs
+++ b/leaf/src/proxy/tun/netstack/stack_impl.rs
@@ -343,7 +343,6 @@ impl AsyncWrite for NetStackImpl {
             if let Some(input_fn) = (*netif_list).input {
                 let err = input_fn(pbuf, netif_list);
                 if err == err_enum_t_ERR_OK as err_t {
-                    trace!("Input packet {}", buf.len());
                     Poll::Ready(Ok(buf.len()))
                 } else {
                     pbuf_free(pbuf);

--- a/leaf/src/proxy/tun/netstack/tcp_stream_context.rs
+++ b/leaf/src/proxy/tun/netstack/tcp_stream_context.rs
@@ -1,0 +1,99 @@
+use futures::task::Waker;
+use std::{
+    cell::UnsafeCell,
+    net::SocketAddr,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::common::mutex::AtomicMutexGuard;
+
+pub struct TcpStreamContextInner {
+    pub local_addr: SocketAddr,
+    pub remote_addr: SocketAddr,
+    pub tx: Option<UnboundedSender<Vec<u8>>>,
+    pub errored: bool,
+    // perhaps a listener level write waker is more appropriate?
+    //
+    // can should wake all connection writes when memory is available.
+    pub write_waker: Option<Waker>,
+}
+
+#[repr(transparent)]
+pub struct TcpStreamContextRef<'a> {
+    ctx: &'a TcpStreamContext,
+}
+
+impl<'a> Deref for TcpStreamContextRef<'a> {
+    type Target = TcpStreamContextInner;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ctx.inner.get() }
+    }
+}
+
+impl<'a> DerefMut for TcpStreamContextRef<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.ctx.inner.get() }
+    }
+}
+
+impl<'a> Drop for TcpStreamContextRef<'a> {
+    fn drop(&mut self) {
+        self.ctx.borrowed.store(false, Ordering::Release);
+    }
+}
+
+/// Context shared by TcpStreamImpl and lwIP callbacks.
+pub struct TcpStreamContext {
+    inner: UnsafeCell<TcpStreamContextInner>,
+    borrowed: AtomicBool,
+}
+
+// Users must hold a lwip_lock to get the mutable reference to inner data,
+// or go through unsafe interfaces.
+unsafe impl Sync for TcpStreamContext {}
+
+impl TcpStreamContext {
+    pub fn new(
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        tx: UnboundedSender<Vec<u8>>,
+    ) -> Self {
+        TcpStreamContext {
+            inner: UnsafeCell::new(TcpStreamContextInner {
+                local_addr,
+                remote_addr,
+                tx: Some(tx),
+                errored: false,
+                write_waker: None,
+            }),
+            borrowed: AtomicBool::new(false),
+        }
+    }
+
+    fn lock_raw(&self) -> TcpStreamContextRef {
+        if self.borrowed.swap(true, Ordering::Acquire) {
+            panic!("TcpStreamContext locked twice within a locked period")
+        }
+        TcpStreamContextRef { ctx: self }
+    }
+
+    /// Access to inner data with lwip_lock locked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another reference to inner data exists.
+    pub fn lock<'a>(&'a self, _guard: &'a AtomicMutexGuard) -> TcpStreamContextRef<'a> {
+        self.lock_raw()
+    }
+
+    /// Access to inner data within a lwIP callback where lwip_lock is guaranteed to be locked.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another reference to inner data exists.
+    pub unsafe fn lock_from_lwip_callback<'a>(ptr: *const Self) -> TcpStreamContextRef<'a> {
+        (&*ptr).lock_raw()
+    }
+}


### PR DESCRIPTION
# Backgronud

When I was trying to integrate leaf netstack into UWP VPN Platform, everything worked except that uplink was extreme slow (up to a few megabits per second) and eventually stopped transmitting. Given [other netstack implementations](https://github.com/YtFlow/Wintun2socks) works just fine with UWP VPN Platform, I assume this problem arises from our netstack.

Another strange thing is, a seemingly useless mutex is used to guard [TcpStreamImpl::waker](https://github.com/eycorsican/leaf/blob/00b5c64bed8e910669e507304e73e4715698cbb9/leaf/src/proxy/tun/netstack/tcp_stream_impl.rs#L115-L119). This does not make sense in that data race cannot happen in a Rust program, otherwise the program would be unsound.

# Current Implementation

The first thing we need to check is all `unsafe` operations. Inside lwIP callbacks, the `arg` argument which is a raw pointer, is dereferenced and reborrowed as an **exclusive** (i.e. mutable) reference.
```rust
pub extern "C" fn tcp_sent_cb(arg: *mut raw::c_void, tpcb: *mut tcp_pcb, len: u16_t) -> err_t {
    unsafe {
        let stream: &mut TcpStreamImpl;
        stream = &mut *(arg as *mut TcpStreamImpl);
              // ^---
```
Let's see if this unsafe operation is legal. The `arg` argument is set during [`TcpStreamImpl::new`](https://github.com/eycorsican/leaf/blob/00b5c64bed8e910669e507304e73e4715698cbb9/leaf/src/proxy/tun/netstack/tcp_stream_impl.rs#L151-L152) where a **shared** (i.e. readonly) reference is coerced to a raw pointer.
```rust
            let arg = &*stream as *const TcpStreamImpl as *mut raw::c_void;
            tcp_arg(pcb, arg);
```
It shows that the `arg`s above is only valid to be used as a **shared** reference. How about obtaining a raw pointer directly from an **exclusive** reference? It seems OK for the lwIP callbacks because they are guaranteed to have `lwip_lock` locked upon calling. However, the ownership of a `TcpStreamImpl` instance is passed all the way up to the async executor. When it `poll`s our `TcpStreamImpl`, an exclusive reference is created again.
```rust
impl AsyncRead for TcpStreamImpl {
    fn poll_read(
        mut self: Pin<&mut Self>,
                   // ^~~~~~~~~
        cx: &mut Context,
        buf: &mut [u8],
    ) -> Poll<io::Result<usize>> {
```
Since tasks may execute in different threads, it is possible that a `TcpStreamImpl` is being polling while an lwIP callback is running. If it really happens, aliasing of `&mut TcpStreamImpl`s occurs and this leads to undefined behavior. Interestingly, data races does not happen all the time, let's say the `write_waker` field that both lwIP callbacks and `poll_write` may access. See how `write_waker` is used in [`poll_write`](https://github.com/eycorsican/leaf/blob/00b5c64bed8e910669e507304e73e4715698cbb9/leaf/src/proxy/tun/netstack/tcp_stream_impl.rs#L274-L308):
```rust
            let _g = lwip_lock.lock();
         // ^~~~~~~~~~~~~~~~~~~~~~~~~~
            let snd_buf_size = (*self.pcb).snd_buf as usize;
            if snd_buf_size < to_write {
                to_write = snd_buf_size;
            }
            if to_write == 0 {
                if let Some(waker) = self.write_waker.as_ref() {
                    if !waker.will_wake(cx.waker()) {
                        self.write_waker.replace(cx.waker().clone());
                    }
                } else {
                    self.write_waker.replace(cx.waker().clone());
                }
                return Poll::Pending;
            }
            let err = tcp_write(
                self.pcb,
                buf.as_ptr() as *const raw::c_void,
                to_write as u16_t,
                TCP_WRITE_FLAG_COPY as u8,
            );
            if err == err_enum_t_ERR_OK as err_t {
                let err = tcp_output(self.pcb);
                if err != err_enum_t_ERR_OK as err_t {
                    warn!("tcp_output err {}", err);
                }
            } else if err == err_enum_t_ERR_MEM as err_t {
                warn!("tcp err_mem");
                if let Some(waker) = self.write_waker.as_ref() {
                    if !waker.will_wake(cx.waker()) {
                        self.write_waker.replace(cx.waker().clone());
                    }
                } else {
                    self.write_waker.replace(cx.waker().clone());
                }
```
Coincidentally, `write_waker` is guarded by `lwip_lock` and thus avoids data race, while the `waker` for read is not. That is probably why we need a mutex for `waker`.

# Proposed Implementation

For the sake of soundness, accesses to shared data from lwIP callbacks and `poll_*` functions must be synchronized by some means. Actually we can simply reuse `lwip_lock` as a guard to synchronize accesses to those data. `UnsafeCell` is used to avoid misoptimization when an exclusive reference to inner data is obtained from a shared reference.

Using the modified implementaion, the throughput is significantly improved in my experiments.
