### PR TITLE
fixed get hostname gateway make IP parse error

### DIFF
--- a/leaf/src/common/cmd_macos.rs
+++ b/leaf/src/common/cmd_macos.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 
 pub fn get_default_ipv4_gateway() -> Result<String> {
     let out = Command::new("route")
+        .arg("-n")
         .arg("get")
         .arg("1")
         .output()
@@ -48,6 +49,7 @@ pub fn get_default_ipv6_gateway() -> Result<String> {
 
 pub fn get_default_interface() -> Result<String> {
     let out = Command::new("route")
+        .arg("-n")
         .arg("get")
         .arg("1")
         .output()


### PR DESCRIPTION
according to route command's help

>      -n      Bypass attempts to print host and network names symbolically when reporting actions.  (The process of translating between symbolic names and numerical equivalents can
>             be quite time consuming, and may require correct operation of the network; thus it may be expedient to forget this, especially when attempting to repair networking
>             operations).

without this argument, sometime will get a hostname gateway, like this

```
$ route get 1
   route to: 0.0.0.1
destination: default
       mask: default
    gateway: openwrt.lan
  interface: en0
      flags: <UP,GATEWAY,DONE,STATIC,PRCLONING>
 recvpipe  sendpipe  ssthresh  rtt,msec    rttvar  hopcount      mtu     expire
       0         0         0         0         0         0      1500         0
```

and https://github.com/eycorsican/leaf/blob/c1d685205ca61aaebb696e614e4745d3fea8d5a0/leaf/src/sys.rs#L99 will use it as a IPv4 address, then the program crash.