### PR TITLE
Fix ipv6 setup

### DIFF
--- a/leaf/src/common/cmd_macos.rs
+++ b/leaf/src/common/cmd_macos.rs
@@ -122,13 +122,13 @@ pub fn add_default_ipv4_route(gateway: Ipv4Addr, ifscope: Option<String>) -> Res
     Ok(())
 }
 
-pub fn add_default_ipv6_route(gateway: Ipv6Addr, ifscope: Option<String>) -> Result<()> {
+pub fn add_default_ipv6_route(gateway: String, ifscope: Option<String>) -> Result<()> {
     if let Some(ifscope) = ifscope {
         Command::new("route")
             .arg("add")
             .arg("-inet6")
             .arg("default")
-            .arg(gateway.to_string())
+            .arg(gateway)
             .arg("-ifscope")
             .arg(ifscope)
             .status()
@@ -138,7 +138,7 @@ pub fn add_default_ipv6_route(gateway: Ipv6Addr, ifscope: Option<String>) -> Res
             .arg("add")
             .arg("-inet6")
             .arg("default")
-            .arg(gateway.to_string())
+            .arg(gateway)
             .status()
             .expect("failed to execute command");
     };

--- a/leaf/src/common/cmd_macos.rs
+++ b/leaf/src/common/cmd_macos.rs
@@ -27,7 +27,6 @@ pub fn get_default_ipv4_gateway() -> Result<String> {
 
 pub fn get_default_ipv6_gateway() -> Result<String> {
     let out = Command::new("route")
-        .arg("-n")
         .arg("get")
         .arg("-inet6")
         .arg("::2")
@@ -44,9 +43,7 @@ pub fn get_default_ipv6_gateway() -> Result<String> {
         .map(str::trim)
         .collect();
     assert!(cols.len() == 2);
-    let parts: Vec<&str> = cols[1].split('%').map(str::trim).collect();
-    assert!(parts.len() >= 1);
-    let res = parts[0].to_string();
+    let res = cols[1].to_string();
     Ok(res)
 }
 

--- a/leaf/src/lib.rs
+++ b/leaf/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(ip)]
 use std::collections::HashMap;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -413,7 +414,19 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
                     .iter()
                     .find(|ifa| ifa.name == item && ifa.is_up() && !ifa.ips.is_empty())
                 {
-                    let mut ips: Vec<IpAddr> = ifa.ips.iter().map(|ipn| ipn.ip()).collect();
+                    let mut ips: Vec<IpAddr> = ifa
+                        .ips
+                        .iter()
+                        .map(|ipn| ipn.ip())
+                        .filter(|&i| {
+                            if let IpAddr::V6(i) = i {
+                                // addr is now an Ipv6Addr ...
+                                return i.is_global();
+                            }
+                            return true;
+                        })
+                        .collect();
+
                     if !ips.is_empty() {
                         bind_ips.append(&mut ips);
                     }

--- a/leaf/src/sys.rs
+++ b/leaf/src/sys.rs
@@ -119,12 +119,12 @@ pub fn post_tun_creation_setup(net_info: &NetInfo) {
                 common::cmd::delete_default_ipv6_route(None).unwrap();
                 common::cmd::delete_default_ipv6_route(Some(iface.clone())).unwrap();
                 common::cmd::add_default_ipv6_route(
-                    option::DEFAULT_TUN_IPV6_GW.parse::<Ipv6Addr>().unwrap(),
+                    option::DEFAULT_TUN_IPV6_GW.to_owned(),
                     None,
                 )
                 .unwrap();
                 common::cmd::add_default_ipv6_route(
-                    ipv6_gw.parse::<Ipv6Addr>().unwrap(),
+                    ipv6_gw.to_owned(),
                     Some(iface.clone()),
                 )
                 .unwrap();
@@ -149,7 +149,7 @@ pub fn post_tun_completion_setup(net_info: &NetInfo) {
         default_interface: Some(iface),
     } = &net_info
     {
-        use std::net::{Ipv4Addr, Ipv6Addr};
+        use std::net::{Ipv4Addr};
         common::cmd::delete_default_ipv4_route(None).unwrap();
         common::cmd::delete_default_ipv4_route(Some(iface.clone())).unwrap();
         common::cmd::add_default_ipv4_route(ipv4_gw.parse::<Ipv4Addr>().unwrap(), None).unwrap();
@@ -164,7 +164,7 @@ pub fn post_tun_completion_setup(net_info: &NetInfo) {
             if let Some(ipv6_gw) = ipv6_gw {
                 common::cmd::delete_default_ipv6_route(None).unwrap();
                 common::cmd::delete_default_ipv6_route(Some(iface.clone())).unwrap();
-                common::cmd::add_default_ipv6_route(ipv6_gw.parse::<Ipv6Addr>().unwrap(), None)
+                common::cmd::add_default_ipv6_route(ipv6_gw.to_owned(), None)
                     .unwrap();
             }
 


### PR DESCRIPTION
This PR fixed the issue here https://github.com/eycorsican/leaf/issues/129#issuecomment-821798124

It works on my machine, but it need to use nightly Rust because use a unstable API https://doc.rust-lang.org/std/net/struct.Ipv6Addr.html#method.is_global

Now, leaf bind the public address

```
\^[[90m[2021-04-18 01:22:09][\^[[90mTRACE\^[[0m\^[[90m] tcp bind [240e:xxx:833:xxxxcb27:f36]:0\^[[0m
```