### PR TITLE
Bind IPv6 addresses with scope ID

### DIFF
--- a/leaf/src/app/dns_client.rs
+++ b/leaf/src/app/dns_client.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{AddrParseError, IpAddr, SocketAddr, SocketAddrV6};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +19,26 @@ use trust_dns_proto::{
 };
 
 use crate::{option, proxy::UdpConnector};
+
+pub fn parse_bind_addr(bind: &str) -> Result<SocketAddr> {
+    let mut split = bind.split('%');
+    let ip_addr = split.next().ok_or(anyhow!("Empty bind address"))?;
+    match split.next() {
+        Some(scope_id) => {
+            let _: Option<()> = split
+                .next()
+                .map(|_| Err(anyhow!("Unexpected % in bind address")))
+                .transpose()?;
+            Ok(SocketAddr::V6(SocketAddrV6::new(
+                ip_addr.parse()?,
+                0,
+                0,
+                scope_id.parse()?,
+            )))
+        }
+        None => Ok(SocketAddr::new(ip_addr.parse()?, 0)),
+    }
+}
 
 pub struct DnsClient {
     bind_addr: SocketAddr,
@@ -76,7 +96,7 @@ impl DnsClient {
 
         Ok(DnsClient {
             servers,
-            bind_addr: SocketAddr::new(dns.bind.parse::<IpAddr>()?, 0),
+            bind_addr: parse_bind_addr(&dns.bind)?,
             hosts,
             ipv4_cache,
             ipv6_cache,
@@ -93,7 +113,7 @@ impl DnsClient {
         let hosts = Self::load_hosts(&dns);
         self.servers = servers;
         self.hosts = hosts;
-        self.bind_addr = SocketAddr::new(dns.bind.parse::<IpAddr>()?, 0);
+        self.bind_addr = parse_bind_addr(&dns.bind)?;
         Ok(())
     }
 

--- a/leaf/src/app/outbound/manager.rs
+++ b/leaf/src/app/outbound/manager.rs
@@ -48,7 +48,7 @@ use crate::proxy::vmess;
 use crate::proxy::ws;
 
 use crate::{
-    app::dns_client::DnsClient,
+    app::dns_client::{parse_bind_addr, DnsClient},
     config::{self, Outbound},
     proxy::{self, OutboundHandler, ProxyHandlerType},
 };
@@ -80,7 +80,7 @@ impl OutboundManager {
                 default_handler.replace(String::from(&outbound.tag));
                 debug!("default handler [{}]", &outbound.tag);
             }
-            let bind_addr = SocketAddr::new(outbound.bind.parse::<IpAddr>()?, 0);
+            let bind_addr = parse_bind_addr(&outbound.bind)?;
             match outbound.protocol.as_str() {
                 #[cfg(feature = "outbound-direct")]
                 "direct" => {
@@ -381,7 +381,7 @@ impl OutboundManager {
                 if handlers.contains_key(&tag) {
                     continue;
                 }
-                let bind_addr = SocketAddr::new(outbound.bind.parse::<IpAddr>()?, 0);
+                let bind_addr = parse_bind_addr(&outbound.bind)?;
                 match outbound.protocol.as_str() {
                     #[cfg(feature = "outbound-tryall")]
                     "tryall" => {


### PR DESCRIPTION
`IpAddr::from_str` does not recognize scope ID in IPv6 bind addresses.

Related issues: https://github.com/YtFlow/Maple/issues/2