### PR TITLE
解决了生成android静态库时的报错

### DIFF
--- a/leaf-ffi/src/lib.rs
+++ b/leaf-ffi/src/lib.rs
@@ -95,6 +95,8 @@ pub extern "C" fn leaf_run(rt_id: u16, config_path: *const c_char) -> i32 {
             config: leaf::Config::File(config_path.to_string()),
             #[cfg(feature = "auto-reload")]
             auto_reload: false,
+            #[cfg(target_os = "android")]
+            socket_protect_path: None,
             runtime_opt: leaf::RuntimeOption::SingleThread,
         };
         if let Err(e) = leaf::start(rt_id, opts) {

--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -153,7 +153,7 @@ async fn protect_socket<S: AsRawFd>(socket: S) -> io::Result<()> {
         if stream.read_i32().await? != 0 {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("failed to protect outbound socket {}", fd),
+                format!("failed to protect outbound socket {}", socket.as_raw_fd()),
             ));
         }
     }
@@ -311,7 +311,7 @@ async fn create_udp_socket(
     bind_socket(&socket, bind_addr, indicator).await?;
 
     #[cfg(target_os = "android")]
-    protect_socket(&socket).await?;
+    protect_socket(socket.as_raw_fd()).await?;
 
     UdpSocket::from_std(socket.into())
 }
@@ -345,7 +345,7 @@ async fn tcp_dial_task(
     bind_socket(&socket, bind_addr, &dial_addr).await?;
 
     #[cfg(target_os = "android")]
-    protect_socket(&socket).await?;
+    protect_socket(socket.as_raw_fd()).await?;
 
     trace!("tcp dialing {}", &dial_addr);
     let stream = timeout(


### PR DESCRIPTION
1、missing `socket_protect_path` 
2、the trait `AsRawFd` is not implemented for `&TcpSocket`