### PR TITLE
Ec private key

### DIFF
--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -169,7 +169,7 @@ colored = "2.0"
 # TLS/rustls/QUIC
 tokio-rustls = { version = "0.23", optional = true }
 webpki-roots = { version = "0.22", optional = true }
-rustls-pemfile = { version = "0.2", optional = true }
+rustls-pemfile = { version = "1.0.2", optional = true }
 
 # TLS/openssl
 openssl-probe = { version = "0.1", optional = true }

--- a/leaf/src/proxy/quic/inbound/datagram.rs
+++ b/leaf/src/proxy/quic/inbound/datagram.rs
@@ -175,10 +175,16 @@ impl InboundDatagramHandler for Handler {
                         match rsa.into_iter().next() {
                             Some(x) => rustls::PrivateKey(x),
                             None => {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    "no private keys found",
-                                ));
+                                let rsa = rustls_pemfile::ec_private_keys(&mut &*key).map_err(quic_err)?;
+                                match rsa.into_iter().next() {
+                                    Some(x) => rustls::PrivateKey(x),
+                                    None => {
+                                        return Err(io::Error::new(
+                                            io::ErrorKind::Other,
+                                            "no private keys found",
+                                        ));
+                                    }
+                                }
                             }
                         }
                     }

--- a/leaf/src/proxy/tls/inbound/stream.rs
+++ b/leaf/src/proxy/tls/inbound/stream.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 #[cfg(feature = "rustls-tls")]
 use {
-    rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys},
+    rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys, ec_private_keys},
     tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig},
     tokio_rustls::TlsAcceptor,
 };
@@ -33,6 +33,10 @@ fn load_keys(path: &Path) -> io::Result<Vec<PrivateKey>> {
     let mut keys2: Vec<PrivateKey> = rsa_private_keys(&mut BufReader::new(File::open(path)?))
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
         .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
+    let mut keys3: Vec<PrivateKey> = ec_private_keys(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
+        .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
+    keys.append(&mut keys3);
     keys.append(&mut keys2);
     Ok(keys)
 }


### PR DESCRIPTION
I found that both tls and quic inbound don't support  ec private key. So I upgraded the version of rustls-pemfile library and added 
the ec private key support for tls and quic.