### PR TITLE
change default congestion controller of both quic inbound and outbound to bbr

### DIFF
--- a/leaf/src/proxy/quic/inbound/datagram.rs
+++ b/leaf/src/proxy/quic/inbound/datagram.rs
@@ -198,6 +198,8 @@ impl InboundDatagramHandler for Handler {
             .max_idle_timeout(Some(quinn::IdleTimeout::from(quinn::VarInt::from_u32(
                 300_000,
             )))); // ms
+        transport_config.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
+
         let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_crypto));
         server_config.transport = Arc::new(transport_config); // TODO share
 

--- a/leaf/src/proxy/quic/outbound/stream.rs
+++ b/leaf/src/proxy/quic/outbound/stream.rs
@@ -79,6 +79,7 @@ impl Manager {
         transport_config.max_idle_timeout(Some(quinn::IdleTimeout::from(quinn::VarInt::from_u32(
             300_000,
         )))); // ms
+        transport_config.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
         client_config.transport = Arc::new(transport_config);
 
         Manager {


### PR DESCRIPTION
Recently I found the performance of TUIC was very impressive. I think it was mainly brought by quinn and  bbr. 
So I think trojan + quic can be as good as tuic if bbr was used.

I changed the default quic congestion controller for both inbound and outbound. The improvement of trojan + quic is astonishing.
Its bandwidth and latency was nearly as good as tuic in my personal test and the bandwidth is far better than go implementation like *ray and sing-box which doesn't support bbr.

PS: In my test I used a green cloud server and the total bandwidth is 100Mbps.  And speedtest  shows

1. The download speed of  sing-box(trojan+quic) is 0.5Mbps
2. The download speed of leaf(trojan+quic+cubic) is 5Mbps
3. The download speed of leaf(trojan+quic+bbr) is 60Mbps