### PR TITLE
fix test_quic_trojan failure problem

### DIFF
--- a/leaf/tests/test_quic_trojan.rs
+++ b/leaf/tests/test_quic_trojan.rs
@@ -77,7 +77,7 @@ fn test_quic_trojan() {
                 "tag": "quic",
                 "settings": {
                     "certificate": "cert.der",
-                    "certificateKey": "key.der"
+                    "certificateKey": "key.der",
                     "alpn": [
                         "http/1.1",
                         "trojan"


### PR DESCRIPTION
There was a comma left out in the json config of test_quic_trojan.rs. I added it so the CI test can pass