### PR TITLE
fix: tun auto for json config

### DIFF
--- a/leaf/src/config/json/config.rs
+++ b/leaf/src/config/json/config.rs
@@ -64,6 +64,7 @@ pub struct ChainInboundSettings {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TunInboundSettings {
+    pub auto: Option<bool>,
     pub fd: Option<i32>,
     pub name: Option<String>,
     pub address: Option<String>,
@@ -332,6 +333,9 @@ pub fn to_internal(json: &mut Config) -> Result<internal::Config> {
                         }
                         if let Some(ext_netmask) = ext_settings.netmask {
                             settings.netmask = ext_netmask;
+                        }
+                        if let Some(ext_auto) = ext_settings.auto {
+                            settings.auto = ext_auto;
                         }
                         if let Some(ext_mtu) = ext_settings.mtu {
                             settings.mtu = ext_mtu;


### PR DESCRIPTION
Hello, I found that the tun auto option in json config file is never read. So I fixed the bug