### PR TITLE
wintun support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ tags
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -56,3 +57,5 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+/.vscode

--- a/leaf-bin/Cargo.toml
+++ b/leaf-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leaf-bin"
-version = "0.7.0"
+version = "0.7.2"
 authors = ["eycorsican <eric.y.corsican@gmail.com>"]
 edition = "2021"
 

--- a/leaf-bin/src/main.rs
+++ b/leaf-bin/src/main.rs
@@ -59,7 +59,7 @@ struct Args {
     test_outbound_timeout: u64,
 
     /// bound interface, explicitly sets the OUTBOUND_INTERFACE environment variable
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     #[argh(option, short = 'b')]
     boundif: Option<String>,
 
@@ -86,7 +86,7 @@ fn main() {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     if let Some(iface) = args.boundif {
         std::env::set_var("OUTBOUND_INTERFACE", &iface);
     }

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -234,6 +234,9 @@ tunio = { git = "https://github.com/GamePad64/tunio.git", branch = "main", featu
 ipnet = "2.7.1"
 netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", branch = "windows", optional = true }
 tokio-util = {version = "0.7.7", features = ["compat"], optional = true }
+windows = { version = "0.46.0", features = [ "Win32_NetworkManagement_IpHelper", 
+"Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis" ] }
+netconfig = "0.4.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
 pnet_datalink = { version = "0.28", package = "pnet_datalink" }

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -238,7 +238,7 @@ windows = { version = "0.46.0", features = [ "Win32_NetworkManagement_IpHelper",
 "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis" ], optional = true}
 netconfig = { version = "0.4.0", optional = true }
 
-[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 pnet_datalink = { version = "0.28", package = "pnet_datalink" }
 libc = "0.2"
 

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -105,7 +105,7 @@ inbound-trojan = ["sha2", "hex"]
 inbound-shadowsocks = ["hkdf", "sha-1", "md-5", "tokio-util"]
 inbound-socks = []
 inbound-http = ["hyper"]
-inbound-tun = ["tun", "netstack-lwip"]
+inbound-tun = ["tun", "tunio", "netstack-lwip", "tokio-util"]
 inbound-ws = ["tungstenite", "tokio-tungstenite", "url", "http"]
 inbound-amux = ["tokio-util"]
 inbound-quic = ["quinn", "rustls", "webpki-roots"]
@@ -226,9 +226,16 @@ notify = { version = "5.0.0-pre.13", optional = true }
 # TUN
 [target.'cfg(any(target_os = "ios", target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 tun = { git = "https://github.com/eycorsican/rust-tun.git", branch = "fork", features = ["async"], optional = true }
-netstack-lwip = { git = "https://github.com/eycorsican/netstack-lwip.git", optional = true }
+# netstack-lwip = { git = "https://github.com/eycorsican/netstack-lwip.git", optional = true }
+netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", branch = "windows", optional = true }
 
-[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "windows"))'.dependencies]
+tunio = { git = "https://github.com/GamePad64/tunio.git", branch = "main", features = ["tokio"], optional = true }
+ipnet = "2.7.1"
+netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", branch = "windows", optional = true }
+tokio-util = {version = "0.7.7", features = ["compat"], optional = true }
+
+[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
 pnet_datalink = { version = "0.28", package = "pnet_datalink" }
 libc = "0.2"
 

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -234,7 +234,7 @@ tunio = { git = "https://github.com/GamePad64/tunio.git", branch = "main", featu
 ipnet = { version = "2.7.1", optional = true}
 netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", branch = "windows", optional = true }
 tokio-util = {version = "0.6", features = ["compat"], optional = true }
-windows = { version = "0.46.0", features = [ "Win32_NetworkManagement_IpHelper", 
+windows = { version = "0.48.0", features = [ "Win32_NetworkManagement_IpHelper", 
 "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis" ], optional = true}
 netconfig = { version = "0.4.0", optional = true }
 

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -105,7 +105,7 @@ inbound-trojan = ["sha2", "hex"]
 inbound-shadowsocks = ["hkdf", "sha-1", "md-5", "tokio-util"]
 inbound-socks = []
 inbound-http = ["hyper"]
-inbound-tun = ["tun", "tunio", "netstack-lwip", "tokio-util"]
+inbound-tun = ["tun", "tunio", "netstack-lwip", "tokio-util", "windows", "netconfig", "netconfig", "ipnet"]
 inbound-ws = ["tungstenite", "tokio-tungstenite", "url", "http"]
 inbound-amux = ["tokio-util"]
 inbound-quic = ["quinn", "rustls", "webpki-roots"]
@@ -231,12 +231,12 @@ netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", bra
 
 [target.'cfg(any(target_os = "windows"))'.dependencies]
 tunio = { git = "https://github.com/GamePad64/tunio.git", branch = "main", features = ["tokio"], optional = true }
-ipnet = "2.7.1"
+ipnet = { version = "2.7.1", optional = true}
 netstack-lwip = { git = "https://github.com/vincentliu77/netstack-lwip.git", branch = "windows", optional = true }
-tokio-util = {version = "0.7.7", features = ["compat"], optional = true }
+tokio-util = {version = "0.6", features = ["compat"], optional = true }
 windows = { version = "0.46.0", features = [ "Win32_NetworkManagement_IpHelper", 
-"Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis" ] }
-netconfig = "0.4.0"
+"Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis" ], optional = true}
+netconfig = { version = "0.4.0", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
 pnet_datalink = { version = "0.28", package = "pnet_datalink" }

--- a/leaf/src/app/inbound/manager.rs
+++ b/leaf/src/app/inbound/manager.rs
@@ -39,7 +39,8 @@ use super::network_listener::NetworkInboundListener;
         target_os = "ios",
         target_os = "android",
         target_os = "macos",
-        target_os = "linux"
+        target_os = "linux",
+        target_os = "windows"
     )
 ))]
 use super::tun_listener::TunInboundListener;
@@ -52,7 +53,8 @@ pub struct InboundManager {
             target_os = "ios",
             target_os = "android",
             target_os = "macos",
-            target_os = "linux"
+            target_os = "linux",
+            target_os = "windows"
         )
     ))]
     tun_listener: Option<TunInboundListener>,
@@ -246,7 +248,8 @@ impl InboundManager {
                 target_os = "ios",
                 target_os = "android",
                 target_os = "macos",
-                target_os = "linux"
+                target_os = "linux",
+                target_os = "windows"
             )
         ))]
         let mut tun_listener: Option<TunInboundListener> = None;
@@ -262,7 +265,8 @@ impl InboundManager {
                         target_os = "ios",
                         target_os = "android",
                         target_os = "macos",
-                        target_os = "linux"
+                        target_os = "linux",
+                        target_os = "windows"
                     )
                 ))]
                 "tun" => {
@@ -301,7 +305,8 @@ impl InboundManager {
                     target_os = "ios",
                     target_os = "android",
                     target_os = "macos",
-                    target_os = "linux"
+                    target_os = "linux",
+                    target_os = "windows"
                 )
             ))]
             tun_listener,
@@ -323,7 +328,8 @@ impl InboundManager {
             target_os = "ios",
             target_os = "android",
             target_os = "macos",
-            target_os = "linux"
+            target_os = "linux",
+            target_os = "windows"
         )
     ))]
     pub fn get_tun_runner(&self) -> Result<Runner> {
@@ -339,7 +345,8 @@ impl InboundManager {
             target_os = "ios",
             target_os = "android",
             target_os = "macos",
-            target_os = "linux"
+            target_os = "linux",
+            target_os = "windows"
         )
     ))]
     pub fn has_tun_listener(&self) -> bool {

--- a/leaf/src/app/inbound/mod.rs
+++ b/leaf/src/app/inbound/mod.rs
@@ -6,7 +6,8 @@ mod network_listener;
         target_os = "ios",
         target_os = "android",
         target_os = "macos",
-        target_os = "linux"
+        target_os = "linux",
+        target_os = "windows"
     )
 ))]
 mod tun_listener;

--- a/leaf/src/app/inbound/mod.rs
+++ b/leaf/src/app/inbound/mod.rs
@@ -12,3 +12,6 @@ mod network_listener;
 mod tun_listener;
 
 pub mod manager;
+
+#[cfg(target_os = "windows")]
+pub mod tunio_wrapper;

--- a/leaf/src/app/inbound/tunio_wrapper/codec.rs
+++ b/leaf/src/app/inbound/tunio_wrapper/codec.rs
@@ -1,0 +1,155 @@
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//                    Version 2, December 2004
+//
+// Copyleft (ↄ) meh. <meh@schizofreni.co> | http://meh.schizofreni.co
+//
+// Everyone is permitted to copy and distribute verbatim or modified
+// copies of this license document, and changing it is allowed as long
+// as the name is changed.
+//
+//            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+//   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+//
+//  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+use std::io;
+
+use byteorder::{NativeEndian, NetworkEndian, WriteBytesExt};
+use bytes::{BufMut, Bytes, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+/// A packet protocol IP version
+#[derive(Debug)]
+enum PacketProtocol {
+    IPv4,
+    IPv6,
+    Other(u8),
+}
+
+// Note: the protocol in the packet information header is platform dependent.
+impl PacketProtocol {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn into_pi_field(&self) -> Result<u16, io::Error> {
+        match self {
+            PacketProtocol::IPv4 => Ok(libc::ETH_P_IP as u16),
+            PacketProtocol::IPv6 => Ok(libc::ETH_P_IPV6 as u16),
+            PacketProtocol::Other(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "neither an IPv4 or IPv6 packet",
+            )),
+        }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    fn into_pi_field(&self) -> Result<u16, io::Error> {
+        match self {
+            PacketProtocol::IPv4 => Ok(libc::PF_INET as u16),
+            PacketProtocol::IPv6 => Ok(libc::PF_INET6 as u16),
+            PacketProtocol::Other(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "neither an IPv4 or IPv6 packet",
+            )),
+        }
+    }
+
+    #[cfg(any(target_os = "windows"))]
+    fn into_pi_field(&self) -> Result<u16, io::Error> {
+        panic!("Not implemented");
+        Ok(0)
+    }
+}
+
+/// A Tun Packet to be sent or received on the TUN interface.
+#[derive(Debug)]
+pub struct TunPacket(PacketProtocol, Bytes);
+
+/// Infer the protocol based on the first nibble in the packet buffer.
+fn infer_proto(buf: &[u8]) -> PacketProtocol {
+    match buf[0] >> 4 {
+        4 => PacketProtocol::IPv4,
+        6 => PacketProtocol::IPv6,
+        p => PacketProtocol::Other(p),
+    }
+}
+
+impl TunPacket {
+    /// Create a new `TunPacket` based on a byte slice.
+    pub fn new(bytes: Vec<u8>) -> TunPacket {
+        let proto = infer_proto(&bytes);
+        TunPacket(proto, Bytes::from(bytes))
+    }
+
+    /// Return this packet's bytes.
+    pub fn get_bytes(&self) -> &[u8] {
+        &self.1
+    }
+
+    pub fn into_bytes(self) -> Bytes {
+        self.1
+    }
+}
+
+/// A TunPacket Encoder/Decoder.
+pub struct TunPacketCodec(bool, i32);
+
+impl TunPacketCodec {
+    /// Create a new `TunPacketCodec` specifying whether the underlying
+    ///  tunnel Device has enabled the packet information header.
+    pub fn new(pi: bool, mtu: i32) -> TunPacketCodec {
+        TunPacketCodec(pi, mtu)
+    }
+}
+
+impl Decoder for TunPacketCodec {
+    type Item = TunPacket;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if buf.is_empty() {
+            return Ok(None);
+        }
+
+        let mut pkt = buf.split_to(buf.len());
+
+        // reserve enough space for the next packet
+        if self.0 {
+            buf.reserve(self.1 as usize + 4);
+        } else {
+            buf.reserve(self.1 as usize);
+        }
+
+        // if the packet information is enabled we have to ignore the first 4 bytes
+        if self.0 {
+            let _ = pkt.split_to(4);
+        }
+
+        let proto = infer_proto(pkt.as_ref());
+        Ok(Some(TunPacket(proto, pkt.freeze())))
+    }
+}
+
+impl Encoder<TunPacket> for TunPacketCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: TunPacket, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.reserve(item.get_bytes().len() + 4);
+        match item {
+            TunPacket(proto, bytes) if self.0 => {
+                // build the packet information header comprising of 2 u16
+                // fields: flags and protocol.
+                let mut buf = Vec::<u8>::with_capacity(4);
+
+                // flags is always 0
+                buf.write_u16::<NativeEndian>(0).unwrap();
+                // write the protocol as network byte order
+                buf.write_u16::<NetworkEndian>(proto.into_pi_field()?)
+                    .unwrap();
+
+                dst.put_slice(&buf);
+                dst.put(bytes);
+            }
+            TunPacket(_, bytes) => dst.put(bytes),
+        }
+        Ok(())
+    }
+}

--- a/leaf/src/app/inbound/tunio_wrapper/mod.rs
+++ b/leaf/src/app/inbound/tunio_wrapper/mod.rs
@@ -1,0 +1,6 @@
+mod rust_tun_wrapper;
+mod codec;
+pub mod win_route;
+
+pub use rust_tun_wrapper::*;
+pub use codec::*;

--- a/leaf/src/app/inbound/tunio_wrapper/rust_tun_wrapper.rs
+++ b/leaf/src/app/inbound/tunio_wrapper/rust_tun_wrapper.rs
@@ -1,0 +1,169 @@
+extern crate tunio;
+use tunio::traits::{DriverT, InterfaceT};
+use tunio::{DefaultAsyncInterface, DefaultDriver};
+use tunio::platform::wintun::AsyncInterface;
+use ipnet::IpNet;
+use std::io;
+
+use core::pin::Pin;
+use std::net::IpAddr;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use core::task::{Context, Poll};
+use tokio_util::codec::Framed;
+use anyhow::{anyhow,Result};
+use futures;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
+use tokio_util::compat::Compat;
+
+use super::codec::*;
+
+
+#[derive(Clone, Debug, Default)]
+pub struct Configuration {
+    pub(crate) name: Option<String>,
+
+    pub(crate) ipnet: Option<IpNet>,
+    pub(crate) destination: Option<IpAddr>,
+    pub(crate) broadcast: Option<IpAddr>,
+    pub(crate) mtu: Option<i32>,
+    pub(crate) enabled: Option<bool>,
+    #[cfg(not(target_os = "windows"))]
+    pub(crate) raw_fd: Option<RawFd>,
+}
+
+impl Configuration {
+
+    /// Set the name.
+    pub fn name<S: AsRef<str>>(&mut self, name: S) -> &mut Self {
+        log::debug!("set tun name {:?}",name.as_ref());
+        self.name = Some(name.as_ref().into());
+        self
+    }
+
+    /// Set the address.
+    pub fn address<S: AsRef<str>>(&mut self, value: S) -> &mut Self {
+        log::debug!("set tun address {:?}",value.as_ref());
+        if let Ok(ipnet) = value.as_ref().parse() {
+            self.ipnet = Some(ipnet);
+        }
+        else {
+            let address:IpAddr = value.as_ref().parse().expect("parsing tun address failed.");
+            self.ipnet = Some(address.into());
+        }
+        self
+    }
+
+    /// Set the destination address.
+    pub fn destination<S: AsRef<str>>(&mut self, value: S) -> &mut Self {
+        log::warn!("tunio_wrapper: destination setting is not implemented");
+        self.destination = Some(value.as_ref().parse().expect("parsing destination address failed."));
+        self
+    }
+
+    /// Set the broadcast address.
+    pub fn broadcast<S: AsRef<str>>(&mut self, value: S) -> &mut Self {
+        self.broadcast = Some(value.as_ref().parse().expect("parsing tun broadcast address failed."));
+        self
+    }
+
+    /// Set the netmask.
+    pub fn netmask<S: AsRef<str>>(&mut self, value: S) -> &mut Self {
+        if value.as_ref().is_empty()
+        {
+            return self;
+        }
+        if let Some(ipnet) = self.ipnet{
+            self.ipnet = Some(IpNet::with_netmask(ipnet.addr(), 
+            value.as_ref().parse().expect("parsing tun netmask failed."))
+            .expect("tun netmask incompatible with address"));
+        }
+        else {
+            log::error!("tun: set address before setting netmask");
+        }
+        self
+    }
+
+    /// Set the MTU.
+    pub fn mtu(&mut self, value: i32) -> &mut Self {
+        self.mtu = Some(value);
+        self
+    }
+
+    /// Set the interface to be enabled once created.
+    pub fn up(&mut self) -> &mut Self {
+        self.enabled = Some(true);
+        self
+    }
+
+    /// Set the interface to be disabled once created.
+    pub fn down(&mut self) -> &mut Self {
+        self.enabled = Some(false);
+        self
+    }
+
+    /// Set the raw fd.
+    #[cfg(not(target_os = "windows"))]
+    pub fn raw_fd(&mut self, fd: RawFd) -> &mut Self {
+        self.raw_fd = Some(fd);
+        self
+    }
+}
+
+pub struct AsyncDevice {
+    interface: AsyncInterface,
+}
+
+impl AsyncDevice {
+    /// Returns a mutable reference to the underlying Device object
+    // pub fn get_mut(&mut self) -> &mut AsyncInterface {
+    //     self.interface.get_mut()
+    // }
+    /// Consumes this AsyncDevice and return a Framed object (unified Stream and Sink interface)
+    pub fn into_framed(mut self) -> Framed<Compat<AsyncInterface>, TunPacketCodec> {
+        let pi = false;
+        let mtu = self.interface.handle().mtu().unwrap_or(1504);
+        let codec = TunPacketCodec::new(pi, mtu.try_into().unwrap());
+        Framed::new(self.interface.compat(), codec)
+    }
+}
+
+pub fn create_as_async(conf: &Configuration) -> Result<AsyncDevice> {
+    let mut driver = DefaultDriver::new().unwrap();
+    let mut interface_config = DefaultAsyncInterface::config_builder();
+    if let Some(name) = &conf.name {
+        interface_config.name(name.clone());
+    }
+
+    #[cfg(target_os = "windows")]
+    interface_config
+        .platform(|mut b| b.description("description".into()).build())?;
+    let interface_config = interface_config.build().unwrap();
+
+    log::debug!("create and start tun device");
+    let interface;
+    if let Some(enabled) = conf.enabled {
+        if(enabled){
+            interface = DefaultAsyncInterface::new_up(&mut driver, interface_config).unwrap();
+        }
+        else {
+            interface = DefaultAsyncInterface::new(&mut driver, interface_config).unwrap();
+        }
+    }
+    else {
+        interface = DefaultAsyncInterface::new(&mut driver, interface_config).unwrap();
+    }
+    let iff = interface.handle();
+
+    if let Some(ipnet) = conf.ipnet {
+        iff.add_address(ipnet)
+        .map_err(|err|anyhow!(err.to_string()))?;
+    }
+    if let Some(mtu) = conf.mtu {
+        iff.set_mtu(mtu.try_into().unwrap())
+        .map_err(|err|anyhow!(err.to_string()))?;
+    }
+
+    // TODO destination set 
+    let device = AsyncDevice{interface: interface};
+    Ok(device)
+}

--- a/leaf/src/app/inbound/tunio_wrapper/win_route.rs
+++ b/leaf/src/app/inbound/tunio_wrapper/win_route.rs
@@ -31,11 +31,14 @@ impl Routable for Interface {
         row.NextHop = SocketAddr::new(next_hop.addr(), 0).into();
         row.Metric = metric;
 
-        unsafe { CreateIpForwardEntry2(&mut row) }.map_err((anyhow::Error::from))
+        unsafe { CreateIpForwardEntry2(&mut row) }
+            .to_hresult()
+            .ok()
+            .map_err(|e| anyhow::anyhow!(e))
     }
 }
 
-// GetBestInterfaceEx() 
+// GetBestInterfaceEx()
 // See https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getbestinterfaceex
 pub fn get_best_interface_ex(dest: IpNet) -> Result<Interface> {
     let mut if_index: u32 = 0;

--- a/leaf/src/app/inbound/tunio_wrapper/win_route.rs
+++ b/leaf/src/app/inbound/tunio_wrapper/win_route.rs
@@ -1,0 +1,35 @@
+use anyhow::{anyhow, Result};
+use ipnet::IpNet;
+use netconfig::Interface;
+use std::net::SocketAddr;
+use windows::Win32::{
+    NetworkManagement::IpHelper::{
+        CreateIpForwardEntry2, InitializeIpForwardEntry, IP_ADDRESS_PREFIX, MIB_IPFORWARD_ROW2,
+    },
+    Networking::WinSock::SOCKADDR_INET,
+};
+
+pub trait Routable {
+    fn add_route(&self, dest: IpNet, next_hop: IpNet, metric: u32) -> Result<()>;
+}
+
+// add_route method adds a route to the interface. Corresponds to CreateIpForwardEntry2 function, with added splitDefault feature.
+// (https://docs.microsoft.com/en-us/windows/desktop/api/netioapi/nf-netioapi-createipforwardentry2)
+impl Routable for Interface {
+    fn add_route(&self, dest: IpNet, next_hop: IpNet, metric: u32) -> Result<()> {
+        let mut row = MIB_IPFORWARD_ROW2::default();
+        unsafe {
+            InitializeIpForwardEntry(&mut row);
+        }
+
+        row.InterfaceIndex = self.index().map_err(|err| anyhow!(err.to_string()))?;
+        row.DestinationPrefix = IP_ADDRESS_PREFIX {
+            Prefix: SocketAddr::new(dest.addr(), 0).into(),
+            PrefixLength: dest.prefix_len(),
+        };
+        row.NextHop = SocketAddr::new(next_hop.addr(), 0).into();
+        row.Metric = metric;
+
+        unsafe { CreateIpForwardEntry2(&mut row) }.map_err((anyhow::Error::from))
+    }
+}

--- a/leaf/src/app/mod.rs
+++ b/leaf/src/app/mod.rs
@@ -20,7 +20,8 @@ pub mod api;
     target_os = "ios",
     target_os = "android",
     target_os = "macos",
-    target_os = "linux"
+    target_os = "linux",
+    target_os = "windows"
 ))]
 pub mod fake_dns;
 

--- a/leaf/src/common/cmd_windows.rs
+++ b/leaf/src/common/cmd_windows.rs
@@ -146,7 +146,7 @@ pub fn add_default_ipv4_route(gateway: Ipv4Addr, interface: String, primary: boo
         // Fixme: use a better method to get the interface alias of tun
         let ifa = Interface::try_from_alias(&*option::DEFAULT_TUN_NAME)
             .map_err(|err| anyhow!(err.to_string()))?;
-        ifa.add_route("0.0.0.0/0".parse()?, format!("0.0.0.0/0").parse()?, 10)?
+        ifa.add_route("0.0.0.0/0".parse()?, format!("0.0.0.0/0").parse()?, 0)?
     }
     Ok(())
 }
@@ -156,7 +156,7 @@ pub fn add_default_ipv6_route(gateway: Ipv6Addr, interface: String, primary: boo
         // Fixme: use a better method to get the interface alias of tun
         let ifa = Interface::try_from_alias(&*option::DEFAULT_TUN_NAME)
             .map_err(|err| anyhow!(err.to_string()))?;
-        ifa.add_route("::/0".parse()?, format!("::/0").parse()?, 10)?
+        ifa.add_route("::/0".parse()?, format!("::/0").parse()?, 0)?
     }
     Ok(())
 }

--- a/leaf/src/common/cmd_windows.rs
+++ b/leaf/src/common/cmd_windows.rs
@@ -1,0 +1,96 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::process::Command;
+
+use anyhow::Result;
+
+// TODO
+// This source file is not completed yes 
+
+pub fn get_default_ipv4_gateway() -> Result<String> {
+    Ok("".into())
+}
+
+pub fn get_default_ipv6_gateway() -> Result<String> {
+    Ok("".into())
+}
+
+pub fn get_default_ipv4_address() -> Result<String> {
+    Ok("".into())
+}
+
+pub fn get_default_ipv6_address() -> Result<String> {
+    Ok("".into())
+}
+
+pub fn get_default_interface() -> Result<String> {
+    Ok("".into())
+}
+
+pub fn add_interface_ipv4_address(
+    name: &str,
+    addr: Ipv4Addr,
+    gw: Ipv4Addr,
+    mask: Ipv4Addr,
+) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_interface_ipv6_address(name: &str, addr: Ipv6Addr, prefixlen: i32) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_default_ipv4_route(gateway: Ipv4Addr, interface: String, primary: bool) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_default_ipv6_route(gateway: Ipv6Addr, interface: String, primary: bool) -> Result<()> { 
+    Ok(())
+}
+
+pub fn delete_default_ipv4_route(ifscope: Option<String>) -> Result<()> {
+    Ok(())
+}
+
+pub fn delete_default_ipv6_route(ifscope: Option<String>) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_default_ipv4_rule(addr: Ipv4Addr) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_default_ipv6_rule(addr: Ipv6Addr) -> Result<()> {
+    Ok(())
+}
+
+pub fn delete_default_ipv4_rule(addr: Ipv4Addr) -> Result<()> {
+    Ok(())
+}
+
+pub fn delete_default_ipv6_rule(addr: Ipv6Addr) -> Result<()> {
+    Ok(())
+}
+
+pub fn get_ipv4_forwarding() -> Result<bool> {
+    Ok(true)
+}
+
+pub fn get_ipv6_forwarding() -> Result<bool> {
+    Ok(true)
+}
+
+pub fn set_ipv4_forwarding(val: bool) -> Result<()> {
+    Ok(())
+}
+
+pub fn set_ipv6_forwarding(val: bool) -> Result<()> {
+    Ok(())
+}
+
+pub fn add_iptable_forward(interface: &str) -> Result<()> {
+    Ok(())
+}
+
+pub fn delete_iptable_forward(interface: &str) -> Result<()> {
+    Ok(())
+}

--- a/leaf/src/common/mod.rs
+++ b/leaf/src/common/mod.rs
@@ -13,3 +13,8 @@ pub use cmd_macos as cmd;
 pub mod cmd_linux;
 #[cfg(target_os = "linux")]
 pub use cmd_linux as cmd;
+
+#[cfg(target_os = "windows")]
+pub mod cmd_windows;
+#[cfg(target_os = "windows")]
+pub use cmd_windows as cmd;

--- a/leaf/src/config/json/config.rs
+++ b/leaf/src/config/json/config.rs
@@ -64,6 +64,7 @@ pub struct ChainInboundSettings {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TunInboundSettings {
+    pub auto: Option<bool>,
     pub fd: Option<i32>,
     pub name: Option<String>,
     pub address: Option<String>,
@@ -333,6 +334,9 @@ pub fn to_internal(json: &mut Config) -> Result<internal::Config> {
                         }
                         if let Some(ext_netmask) = ext_settings.netmask {
                             settings.netmask = ext_netmask;
+                        }
+                        if let Some(ext_auto) = ext_settings.auto {
+                            settings.auto = ext_auto;
                         }
                         if let Some(ext_mtu) = ext_settings.mtu {
                             settings.mtu = ext_mtu;

--- a/leaf/src/config/json/config.rs
+++ b/leaf/src/config/json/config.rs
@@ -287,7 +287,8 @@ pub fn to_internal(json: &mut Config) -> Result<internal::Config> {
                     target_os = "ios",
                     target_os = "android",
                     target_os = "macos",
-                    target_os = "linux"
+                    target_os = "linux",
+                    target_os = "windows"
                 ))]
                 "tun" => {
                     if ext_inbound.settings.is_none() {

--- a/leaf/src/lib.rs
+++ b/leaf/src/lib.rs
@@ -37,7 +37,7 @@ pub mod util;
 #[cfg(any(target_os = "ios", target_os = "macos", target_os = "android"))]
 pub mod mobile;
 
-#[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
+#[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 mod sys;
 
 #[derive(Error, Debug)]
@@ -418,14 +418,14 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
         .map_err(Error::Config)?;
     runners.append(&mut inbound_net_runners);
 
-    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
+    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let net_info = if inbound_manager.has_tun_listener() && inbound_manager.tun_auto() {
         sys::get_net_info()
     } else {
         sys::NetInfo::default()
     };
 
-    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
+    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         if let sys::NetInfo {
             default_interface: Some(iface),
@@ -447,14 +447,15 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
             target_os = "ios",
             target_os = "android",
             target_os = "macos",
-            target_os = "linux"
+            target_os = "linux",
+            target_os = "windows"
         )
     ))]
     if let Ok(r) = inbound_manager.get_tun_runner() {
         runners.push(r);
     }
 
-    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
+    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     sys::post_tun_creation_setup(&net_info);
 
     let runtime_manager = RuntimeManager::new(
@@ -537,7 +538,7 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
 
     rt.block_on(futures::future::select_all(tasks));
 
-    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
+    #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     sys::post_tun_completion_setup(&net_info);
 
     drop(inbound_manager);

--- a/leaf/src/option/mod.rs
+++ b/leaf/src/option/mod.rs
@@ -252,11 +252,11 @@ lazy_static! {
     };
 
     pub static ref DEFAULT_TUN_IPV4_ADDR: String = {
-        get_env_var_or("DEFAULT_TUN_IPV4_ADDR", "240.255.0.2".to_string())
+        get_env_var_or("DEFAULT_TUN_IPV4_ADDR", "172.21.0.2".to_string())
     };
 
     pub static ref DEFAULT_TUN_IPV4_GW: String = {
-        get_env_var_or("DEFAULT_TUN_IPV4_GW", "240.255.0.1".to_string())
+        get_env_var_or("DEFAULT_TUN_IPV4_GW", "172.21.0.1".to_string())
     };
 
     pub static ref DEFAULT_TUN_IPV4_MASK: String = {

--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -72,7 +72,8 @@ pub mod tryall;
         target_os = "ios",
         target_os = "android",
         target_os = "macos",
-        target_os = "linux"
+        target_os = "linux",
+        target_os = "windows"
     )
 ))]
 pub mod tun;


### PR DESCRIPTION
Hello, recently, I added wintun support for leaf. I used tunio as the  frontend of wintun and to make my code as less 
invasive as possible, I wrapped the tunio api in the way similar to rust-tun. And I put the tunio_wrapper code in the path
leaf/leaf/app/inbound/tunio_wrapper (I'm not sure whether it should be put here).   I'm a newbie in rust. If you have
any advice, please tell me.

## What I have done:

- Wrapped the tunio api in the way similar to rust-tun
- implemented the bind to interface feature on windows platform. I found that on *nix a socket can be used after binding
to interface (used setsockopt) without bind function. But on windows after binding to interface, an explicit calling
bind function is needed.
- add windows default route (refered sing-tun code)
- change the default tun ip to standard private ip. The former IP is not a standard private ip. Setting such
 an ip for tun seems to be forbidden on windows.

## Build Requirement

- clang toolchain and msvc toolchain (for tunio)
- ~~leaf uses `pnet_datalink` to get network information, this requires on windows,
   see [libpnet](https://github.com/libpnet/libpnet):~~
   -  ~~You must use a version of Rust which uses the MSVC toolchain.~~
   - ~~You must have [WinPcap](https://www.winpcap.org/) or [npcap](https://nmap.org/npcap/) installed (tested with version 
      WinPcap 4.1.3) (If using npcap, make sure to install with the "Install Npcap in WinPcap API-compatible Mode")~~
   - ~~You must use Packet.lib from the [WinPcap Developers pack](https://www.winpcap.org/devel.htm).
     You can place it in any of the locations listed in the %LIB%/$Env:LIB environment variables. 
     For the 64 bit toolchain it is in WpdPack/Lib/x64/Packet.lib, for the 32 bit toolchain, it is in WpdPack/Lib/Packet.lib.~~


## Running Requirement

- ~~leaf uses pnet_datalink to get network information. On windows it requires  WinPcap  or npcap to be installed.~~
- As always, wintun.dll should be placed in the same directory of leaf executable. See [wintun](https://www.wintun.net/)

## Limitation
- tun gateway setting not implemented
- gateway mode not supported
- IPV6 auto route not tested

## about netstack-lwip
I found that netstack-lwip can't be built directly. I requires a user implementation of `lwip_strerr` function, see (https://github.com/eycorsican/netstack-lwip/pull/6) . Since 
my pr of netstack-lwip has not been accepted. I changed the netstack-lwip dependency to my fork temporarily. 
Another solution may be implementing  `lwip_strerr` in leaf.

I think the dependency on `pnet_datalink` on windows is troublesome. 
Maybe replace it separately for windows platform later?



