### PR TITLE
inbound/http: fixed plain http request failure

### DIFF
--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -107,7 +107,7 @@ outbound-vmess = ["lz_fnv", "cfb-mode", "hmac", "aes", "sha3", "digest", "uuid",
 inbound-trojan = ["sha2", "hex"]
 inbound-shadowsocks = ["hkdf", "sha-1", "md-5", "tokio-util"]
 inbound-socks = []
-inbound-http = ["hyper/server", "hyper/http1"]
+inbound-http = ["http"]
 inbound-tun = ["tun", "netstack-lwip"]
 inbound-ws = ["tungstenite", "tokio-tungstenite", "url", "http"]
 inbound-amux = ["tokio-util"]
@@ -187,9 +187,6 @@ tokio-tungstenite = { version = "0.16", optional = true }
 # WebSocket
 url = { version = "2.2", optional = true }
 http = { version = "0.2", optional = true }
-
-# HTTP inbound
-hyper = { version = "0.14", default-features = false, optional = true }
 
 # SOCKS outbound
 async-socks5 = { version = "0.5", optional = true }

--- a/leaf/src/proxy/http/inbound/stream.rs
+++ b/leaf/src/proxy/http/inbound/stream.rs
@@ -1,53 +1,148 @@
-use std::convert::TryFrom;
 use std::io;
-use std::{net::IpAddr, pin::Pin, task::Poll};
+use std::str;
+use std::cmp;
+use std::convert::TryFrom;
+use std::{net::IpAddr, pin::Pin, task::Poll, task::Context};
 
 use anyhow::Result;
+use tokio::io::{AsyncWriteExt, AsyncReadExt, ReadBuf};
+use bytes::BytesMut;
 use async_trait::async_trait;
-use futures::future::{self, Future};
-use hyper::{server::conn::Http, service::Service, Body, Request, Response};
-use log::*;
+use ::http::{Method, Uri};
 
 use crate::{
     proxy::*,
     session::{Session, SocksAddr},
 };
 
-struct ProxyService {
-    uri: String,
+const BUFFER_SIZE: usize = 1024;
+const EOL: [u8; 2] = [13, 10];
+const EOH: [u8; 4] = [13, 10, 13, 10];
+
+/// Parse destination
+impl TryFrom<&Uri> for SocksAddr {
+    type Error = io::Error;
+    fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
+        let (host, port) = (
+            uri.host().ok_or(io::Error::new(io::ErrorKind::InvalidInput, format!("malformed uri: {}", uri)))?,
+            uri.port_u16().or_else(|| {
+                match uri.scheme_str() {
+                    Some("ssh") => Some(22),
+                    Some("smtp") => Some(25),
+                    Some("http") => Some(80),
+                    Some("https") => Some(443),
+                    _ => None,
+                }
+            }).ok_or(io::Error::new(io::ErrorKind::InvalidInput, format!("unknown scheme '{}' must provide a port", uri.scheme_str().unwrap_or(""))))?
+        );
+        let addr = if let Ok(host) = host.parse::<IpAddr>() {
+            SocksAddr::from((host, port))
+        } else {
+            SocksAddr::try_from((host, port))?
+        };
+        Ok(addr)
+    }
 }
 
-impl ProxyService {
-    pub fn new() -> Self {
-        ProxyService {
-            uri: "".to_string(),
+struct HttpStream {
+    cache: Vec<u8>,
+    destination: Option<SocksAddr>,
+    origin: AnyStream,
+}
+
+impl HttpStream {
+    async fn sniff(&mut self) -> io::Result<()> {
+        let (head, mut rest) = self.drain(&EOH).await?;
+        let (request_line, mut header) = self.split_slice_once(&head, &EOL)
+            .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "malformed request"))?;
+        let (method, uri, version) = self.parse_request_line(&request_line)?;
+
+        self.destination = Some(SocksAddr::try_from(&uri)?);
+
+        // different target formats for different strategies, see: https://www.rfc-editor.org/rfc/rfc7230#section-5.3
+        // authority format (for https request)
+        if method == Method::CONNECT {
+            self.origin.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n").await?;
+            return Ok(());
+        }
+        // absolute uri format (for http request)
+        else if uri.scheme().is_some() {
+            let path_and_query = uri.path_and_query().map(|paq| paq.as_str()).unwrap_or("/");
+            let new_request_line = format!("{} {} {}", method, path_and_query, version);
+            self.cache.clear();
+            self.cache.append(&mut new_request_line.into_bytes());
+            self.cache.append(&mut header);
+            self.cache.append(&mut rest);
+            return Ok(());
+        } else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "unsupported request target form"));
         }
     }
 
-    pub fn get_uri(&self) -> &String {
-        &self.uri
+    async fn drain(&mut self, stop_sign: &[u8]) -> io::Result<(Vec<u8>, Vec<u8>)> {
+        let mut data = Vec::new();
+        let mut buf = BytesMut::with_capacity(BUFFER_SIZE);
+        loop {
+            buf.clear();
+            let n = self.origin.read_buf(&mut buf).await?;
+            data.extend_from_slice(&buf[..n]);
+            match self.split_slice_once(&data, stop_sign) {
+                Some(v) => return Ok(v),
+                None => continue,
+            }
+        }
+    }
+
+    fn split_slice_once(&self, s: &[u8], sep: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        s.windows(sep.len()).position(|w| w == sep).map(|loc| (s[..loc].to_vec(), s[loc..].to_vec()))
+    }
+
+    fn parse_request_line(&self, request_line: &[u8]) -> io::Result<(Method, Uri, String)> {
+        let mut tokens = str::from_utf8(request_line).unwrap_or("").splitn(3, ' ');
+        let method = match Method::try_from(tokens.next().unwrap_or("")) {
+            Ok(v) => v,
+            Err(_e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid method")),
+        };
+        let uri = match Uri::try_from(tokens.next().unwrap_or("")) {
+            Ok(v) => v,
+            Err(_e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid uri")),
+        };
+        let version = tokens.next().unwrap_or("HTTP/1.1");
+        Ok((method, uri, version.to_string()))
     }
 }
 
-#[allow(clippy::type_complexity)]
-impl Service<Request<Body>> for ProxyService {
-    type Error = Box<dyn std::error::Error + Send + Sync>;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-    type Response = Response<Body>;
+impl AsyncRead for HttpStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if !self.cache.is_empty() {
+            let n = cmp::min(buf.capacity(), self.cache.len());
+            let cached_data = self.cache.drain(..n);
+            buf.put_slice(cached_data.as_slice());
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut self.origin).poll_read(cx, buf)
+    }
+}
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
-        self.uri = req.uri().to_string();
-        Box::pin(future::ready(Ok(Response::builder()
-            .status(200)
-            .body(hyper::Body::empty())
-            .unwrap())))
+impl AsyncWrite for HttpStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.origin).poll_write(cx, buf)
     }
 
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> Poll<std::result::Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.origin).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.origin).poll_shutdown(cx)
     }
 }
 
@@ -58,47 +153,17 @@ impl InboundStreamHandler for Handler {
     async fn handle<'a>(
         &'a self,
         mut sess: Session,
-        stream: Box<dyn ProxyStream>,
+        stream: AnyStream,
     ) -> std::io::Result<AnyInboundTransport> {
-        let http = Http::new();
-        let proxy_service = ProxyService::new();
-        let conn = http
-            .serve_connection(stream, proxy_service)
-            .without_shutdown();
-        let parts = match conn.await {
-            Ok(v) => v,
-            Err(err) => {
-                debug!("accept conn failed: {}", err);
-                return Err(io::Error::new(io::ErrorKind::Other, "unspecified"));
-            }
+        let mut http_stream = HttpStream {
+            cache: Vec::new(),
+            destination: None,
+            origin: stream,
         };
+        http_stream.sniff().await?;
 
-        let uri = parts.service.get_uri();
-        let host_port: Vec<&str> = uri.split(':').collect();
-        if host_port.len() != 2 {
-            debug!("invalid target {:?}", uri);
-            return Err(io::Error::new(io::ErrorKind::Other, "unspecified"));
-        }
+        sess.destination = http_stream.destination.clone().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "unspecified"))?;
 
-        let destination = if let Ok(port) = host_port[1].parse::<u16>() {
-            if let Ok(ip) = host_port[0].parse::<IpAddr>() {
-                SocksAddr::from((ip, port))
-            } else {
-                match SocksAddr::try_from((host_port[0], port)) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        debug!("invalid target {:?}: {}", uri, err);
-                        return Err(io::Error::new(io::ErrorKind::Other, "unspecified"));
-                    }
-                }
-            }
-        } else {
-            debug!("invalid target {:?}", uri);
-            return Err(io::Error::new(io::ErrorKind::Other, "unspecified"));
-        };
-
-        sess.destination = destination;
-
-        Ok(InboundTransport::Stream(Box::new(parts.io), sess))
+        Ok(InboundTransport::Stream(Box::new(http_stream), sess))
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/eycorsican/leaf/issues/331 , previous implementation only support CONNECT mode, I made it support AbsoluteURI mode (which used by plain http request).

Since sniffing is required for detecting Request Target Format (`Authority` vs `AbsoluteURI`) and the Request-Line needs to be replaced in `AbsoluteURI` mode, I wrapped original stream and abandoned using `hyper` as a http server.

`hyper` dependency was also removed.

Please review, any suggestion is welcome.