### PR TITLE
inbound/http: ensure the host header field as the same as absolute uri

### DIFF
--- a/leaf/src/proxy/http/inbound/stream.rs
+++ b/leaf/src/proxy/http/inbound/stream.rs
@@ -19,21 +19,27 @@ const BUFFER_SIZE: usize = 1024;
 const EOL: [u8; 2] = [13, 10];
 const EOH: [u8; 4] = [13, 10, 13, 10];
 
+fn bad_request() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "bad request")
+}
+
+fn split_slice_once(s: &[u8], sep: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    s.windows(sep.len()).position(|w| w == sep).map(|loc| (s[..loc].to_vec(), s[loc..].to_vec()))
+}
+
 /// Parse destination
 impl TryFrom<&Uri> for SocksAddr {
     type Error = io::Error;
     fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
         let (host, port) = (
-            uri.host().ok_or(io::Error::new(io::ErrorKind::InvalidInput, format!("malformed uri: {}", uri)))?,
+            uri.host().ok_or(bad_request())?,
             uri.port_u16().or_else(|| {
                 match uri.scheme_str() {
-                    Some("ssh") => Some(22),
-                    Some("smtp") => Some(25),
                     Some("http") => Some(80),
                     Some("https") => Some(443),
                     _ => None,
                 }
-            }).ok_or(io::Error::new(io::ErrorKind::InvalidInput, format!("unknown scheme '{}' must provide a port", uri.scheme_str().unwrap_or(""))))?
+            }).ok_or(bad_request())?
         );
         let addr = if let Ok(host) = host.parse::<IpAddr>() {
             SocksAddr::from((host, port))
@@ -41,6 +47,100 @@ impl TryFrom<&Uri> for SocksAddr {
             SocksAddr::try_from((host, port))?
         };
         Ok(addr)
+    }
+}
+
+/// https://www.rfc-editor.org/rfc/rfc7230#section-5.3
+enum TargetFormat {
+    Origin,
+    Absolute,
+    Authority,
+    Asterisk,
+}
+
+struct RequestHead {
+    method: Method,
+    uri: Uri,
+    version: String,
+    headers: Vec<(String, String)>,
+    target_format: TargetFormat,
+}
+
+impl RequestHead {
+    fn parse_request_line(request_line: &[u8]) -> io::Result<(Method, Uri, String)> {
+        let mut tokens = str::from_utf8(request_line).unwrap_or("").splitn(3, ' ');
+        let method = match Method::try_from(tokens.next().unwrap_or("")) {
+            Ok(v) => v,
+            Err(_e) => return Err(bad_request()),
+        };
+        let uri = match Uri::try_from(tokens.next().unwrap_or("")) {
+            Ok(v) => v,
+            Err(_e) => return Err(bad_request()),
+        };
+        let version = tokens.next().unwrap_or("HTTP/1.1");
+        Ok((method, uri, version.to_string()))
+    }
+
+    fn parse_headers(header_lines: &[u8]) -> io::Result<Vec<(String, String)>> {
+        let mut headers = Vec::new();
+        let lines = str::from_utf8(header_lines).unwrap_or("").split("\r\n");
+        for line in lines {
+            let (name, value) = match line.split_once(':') {
+                Some((n, v)) => (n.trim(), v.trim()),
+                None => continue,
+            };
+            headers.push((name.to_string(), value.to_string()));
+        }
+        Ok(headers)
+    }
+
+    fn set_header(&mut self, name: String, value: String) {
+        for (i, (n, _v)) in self.headers.iter().enumerate() {
+            if n.to_lowercase() == name.to_lowercase() {
+                self.headers[i] = (n.clone(), value);
+                return;
+            }
+        }
+    }
+}
+
+impl Into<Vec<u8>> for RequestHead {
+    fn into(self) -> Vec<u8> {
+        let mut head = Vec::new();
+        let request_line = format!("{} {} {}\r\n", self.method, self.uri, self.version);
+        head.append(&mut request_line.into_bytes());
+        for (name, value) in self.headers {
+            let header = format!("{}: {}\r\n", name, value);
+            head.append(&mut header.into_bytes());
+        }
+        head.extend_from_slice("\r\n".as_bytes());
+        head
+    }
+}
+
+impl TryFrom<Vec<u8>> for RequestHead {
+    type Error = io::Error;
+    fn try_from(head: Vec<u8>) -> Result<Self, Self::Error> {
+        let (request_line, header) = split_slice_once(&head, &EOL)
+            .ok_or(bad_request())?;
+        let (method, uri, version) = RequestHead::parse_request_line(&request_line)?;
+        let headers = RequestHead::parse_headers(&header)?;
+        let target_format = if uri.to_string() == "*" {
+            TargetFormat::Asterisk
+        } else if uri.scheme().is_some() {
+            TargetFormat::Absolute
+        } else if method == Method::CONNECT {
+            TargetFormat::Authority
+        } else {
+            TargetFormat::Origin
+        };
+        Ok(RequestHead {
+            method,
+            uri,
+            version,
+            headers,
+            target_format,
+        })
     }
 }
 
@@ -52,30 +152,27 @@ struct HttpStream {
 
 impl HttpStream {
     async fn sniff(&mut self) -> io::Result<()> {
-        let (head, mut rest) = self.drain(&EOH).await?;
-        let (request_line, mut header) = self.split_slice_once(&head, &EOL)
-            .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "malformed request"))?;
-        let (method, uri, version) = self.parse_request_line(&request_line)?;
+        let (head_buf, mut rest_buf) = self.drain(&EOH).await?;
+        let mut head = RequestHead::try_from(head_buf)?;
 
-        self.destination = Some(SocksAddr::try_from(&uri)?);
+        let addr = SocksAddr::try_from(&head.uri)?;
+        self.destination = Some(addr.clone());
 
-        // different target formats for different strategies, see: https://www.rfc-editor.org/rfc/rfc7230#section-5.3
-        // authority format (for https request)
-        if method == Method::CONNECT {
-            self.origin.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n").await?;
-            return Ok(());
-        }
-        // absolute uri format (for http request)
-        else if uri.scheme().is_some() {
-            let path_and_query = uri.path_and_query().map(|paq| paq.as_str()).unwrap_or("/");
-            let new_request_line = format!("{} {} {}", method, path_and_query, version);
-            self.cache.clear();
-            self.cache.append(&mut new_request_line.into_bytes());
-            self.cache.append(&mut header);
-            self.cache.append(&mut rest);
-            return Ok(());
-        } else {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "unsupported request target form"));
+        match head.target_format {
+            TargetFormat::Absolute => {
+                let path_and_query = head.uri.path_and_query().map(|paq| paq.as_str()).unwrap_or("/");
+                head.uri = path_and_query.parse().unwrap();
+                head.set_header("host".to_string(), addr.to_string());
+                self.cache.clear();
+                self.cache.append(&mut head.into());
+                self.cache.append(&mut rest_buf);
+                return Ok(());
+            },
+            TargetFormat::Authority => {
+                self.origin.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n").await?;
+                return Ok(());
+            },
+            _ => return Err(bad_request()),
         }
     }
 
@@ -86,29 +183,11 @@ impl HttpStream {
             buf.clear();
             let n = self.origin.read_buf(&mut buf).await?;
             data.extend_from_slice(&buf[..n]);
-            match self.split_slice_once(&data, stop_sign) {
+            match split_slice_once(&data, stop_sign) {
                 Some(v) => return Ok(v),
                 None => continue,
             }
         }
-    }
-
-    fn split_slice_once(&self, s: &[u8], sep: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
-        s.windows(sep.len()).position(|w| w == sep).map(|loc| (s[..loc].to_vec(), s[loc..].to_vec()))
-    }
-
-    fn parse_request_line(&self, request_line: &[u8]) -> io::Result<(Method, Uri, String)> {
-        let mut tokens = str::from_utf8(request_line).unwrap_or("").splitn(3, ' ');
-        let method = match Method::try_from(tokens.next().unwrap_or("")) {
-            Ok(v) => v,
-            Err(_e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid method")),
-        };
-        let uri = match Uri::try_from(tokens.next().unwrap_or("")) {
-            Ok(v) => v,
-            Err(_e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid uri")),
-        };
-        let version = tokens.next().unwrap_or("HTTP/1.1");
-        Ok((method, uri, version.to_string()))
     }
 }
 
@@ -162,7 +241,7 @@ impl InboundStreamHandler for Handler {
         };
         http_stream.sniff().await?;
 
-        sess.destination = http_stream.destination.clone().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "unspecified"))?;
+        sess.destination = http_stream.destination.clone().ok_or(bad_request())?;
 
         Ok(InboundTransport::Stream(Box::new(http_stream), sess))
     }


### PR DESCRIPTION
As mentioned in https://github.com/eycorsican/leaf/pull/384#issuecomment-1537381543 , force set Host header field as the same as it in AbsoluteURI, with a little refactory 