### PR TITLE
outbound/failover: catch more error to try next actor

### DIFF
--- a/leaf/src/proxy/failover/stream.rs
+++ b/leaf/src/proxy/failover/stream.rs
@@ -168,7 +168,18 @@ impl OutboundStreamHandler for Handler {
                 Duration::from_secs(self.fail_timeout as u64),
                 a.stream()?.handle(
                     sess,
-                    connect_stream_outbound(sess, self.dns_client.clone(), a).await?,
+                    match connect_stream_outbound(sess, self.dns_client.clone(), a).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            trace!(
+                                "[{}] failed to handle [{}]: {}",
+                                a.tag(),
+                                sess.destination,
+                                e,
+                            );
+                            continue;
+                        }
+                    },
                 ),
             )
             .await


### PR DESCRIPTION
I found the failover feature works for macOS (binary), but fails on Android device (tun), with the same configuration.

# Test

With the following `config.json` (keep 10001 closing and 10002 listening):

```json
{
    "log": { "level": "trace" },
    "dns": { "servers": [ "223.5.5.5", "119.29.29.29" ] },
    "inbounds": [
        ...
    ],
    "outbounds": [
        { "protocol": "failover", "settings": { "actors": ["trojan_tls_1", "trojan_tls_2"] }, "tag": "proxy" },

        { "protocol": "chain", "settings": { "actors": ["tls_1", "trojan_1"] }, "tag": "trojan_tls_1" },
        { "protocol": "tls", "tag": "tls_1" },
        { "protocol": "trojan", "settings": { "address": "somewhere.net", "port": 10001, "password": "mypassword" }, "tag": "trojan_1" },

        { "protocol": "chain", "settings": { "actors": ["tls_2", "trojan_2"] }, "tag": "trojan_tls_2" },
        { "protocol": "tls", "tag": "tls_2" },
        { "protocol": "trojan", "settings": { "address": "somewhere.net", "port": 10002, "password": "mypassword" }, "tag": "trojan_2" }
    ]
}
```

When I run it on macOS with `cargo run`, everything works like a charm. But on the Android device, it never try to the next actor.

After a while of searching, I found the trace log `[{}] failed to handle [{}]: {}` never shows, which should print by:

- [stream.rs#L191](https://github.com/eycorsican/leaf/blob/2f09e6896f01d37260dbe145d47d80d1272096d0/leaf/src/proxy/failover/stream.rs#L191)
- [stream.rs#L201](https://github.com/eycorsican/leaf/blob/2f09e6896f01d37260dbe145d47d80d1272096d0/leaf/src/proxy/failover/stream.rs#L201)

So I unfolded the `?` in the [stream.rs#L171](https://github.com/eycorsican/leaf/blob/2f09e6896f01d37260dbe145d47d80d1272096d0/leaf/src/proxy/failover/stream.rs#L171) and made it continue for error, problem resolved.

After resolving, we can see different logs:

```
// macOS log
[2023-05-23 14:47:01][TRACE] [trojan_tls_1] failed to handle [static.xx.fbcdn.net:443]: connect tls failed: tls handshake eof
// Android log, error caused from `connect_stream_outbound`
[2023-05-23 13:43:52][TRACE] [trojan_tls_1] failed to handle [10317026331684849432917912dnsleak.linkv.site:443]: all attempts failed, last error: Connection refused (os error 111)
```

Still don't know why there are different behaviors between macOS and Android, but it works.

Please review at your convenience.