### PR TITLE
FEAT: Implemented UDP SOCKS5 forwarding by hostname

### DIFF
--- a/leaf/src/proxy/socks/outbound/datagram.rs
+++ b/leaf/src/proxy/socks/outbound/datagram.rs
@@ -104,12 +104,14 @@ where
                     .map_ok(|_| buf.len())
                     .map_err(|x| Error::new(ErrorKind::Other, x))
                     .await
+            },
+            SocksAddr::Domain(domain, port) => {
+                self.0
+                    .send_to(buf, (domain.to_owned(), *port))
+                    .map_ok(|_| buf.len())
+                    .map_err(|x| Error::new(ErrorKind::Other, x))
+                    .await
             }
-            // FIXME for this, we need our own socks5 impl
-            _ => Err(Error::new(
-                ErrorKind::Other,
-                "socks outbound does not support sending UDP packets to domain address",
-            )),
         }
     }
 


### PR DESCRIPTION
Hi All!

I had the need to use `leaf` as a tun2socks implementation in iOS, but I encountered that the UDP SOCKS5 forwarding was incomplete. 

I made this small improvement in order to allow UDP Associate communications, but using a hostname instead of only an IP. There was a `FIXME` stating that a custom impl would be needed, but I think the `async-socks5` crate has evolved over time, and only needed a small adaptation.

Have a nice day!