### PR TITLE
leaf-ffi: add missing auto-reload feature

### DIFF
--- a/leaf-ffi/Cargo.toml
+++ b/leaf-ffi/Cargo.toml
@@ -16,10 +16,12 @@ default = [
 
 default-ring = [
     "leaf/default-ring",
+    "auto-reload",
 ]
 
 default-openssl = [
     "leaf/default-openssl",
+    "auto-reload",
 ]
 
 outbound-quic = [


### PR DESCRIPTION
The `leaf-ffi` compilation error, missing `auto-reload` feature.