### PR TITLE
conf: fix `std::env::set_var` with NUL byte

### DIFF
--- a/leaf/src/config/conf/config.rs
+++ b/leaf/src/config/conf/config.rs
@@ -257,7 +257,7 @@ where
 pub fn from_lines(lines: Vec<io::Result<String>>) -> Result<Config> {
     let env_lines = get_lines_by_section("Env", lines.iter());
     for line in env_lines {
-        let parts: Vec<&str> = line.split('=').map(str::trim).collect();
+        let parts: Vec<&str> = line.split('=').map(|s| s.trim_matches('\u{0}')).map(str::trim).collect();
         if parts.len() != 2 {
             continue;
         }


### PR DESCRIPTION
Running fuzzing test with cargo-honggfuzz and got error log below.

```bash
thread 'main' panicked at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/std/src/env.rs:364:9:
failed to set environment variable `"m\0\0\0]"` to `""`: file name contained an unexpected NUL byte
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/core/src/panicking.rs:74:14
   2: std::env::set_var::{{closure}}
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/std/src/env.rs:364:9
   3: core::result::Result<T,E>::unwrap_or_else
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/core/src/result.rs:1457:23
   4: std::env::set_var
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/std/src/env.rs:363:43
   5: leaf::config::conf::config::from_lines
             at /root/develop/leaf/leaf/src/config/conf/config.rs:264:9
   6: leaf::config::conf::config::from_string
             at /root/develop/leaf/leaf/src/config/conf/config.rs:1518:22
   7: leaf::config::from_string
             at /root/develop/leaf/leaf/src/config/mod.rs:27:16
   8: fuzz_target_1::main::{{closure}}
             at ./fuzz_targets/fuzz_target_1.rs:18:21
   9: honggfuzz::fuzz
             at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/honggfuzz-0.5.56/src/lib.rs:317:5
  10: fuzz_target_1::main
             at ./fuzz_targets/fuzz_target_1.rs:17:9
  11: core::ops::function::FnOnce::call_once
             at /rustc/7042c269c166191cd5d8daf0409890903df7af57/library/core/src/ops/function.rs:250:5
```
```bash
root@server:~/develop/leaf/leaf/fuzz# cat fuzz_targets/fuzz_target_1.rs
use honggfuzz::fuzz;

extern crate leaf;

fn main() {
    // Here you can parse `std::env::args and
    // setup / initialize your project

    // You have full control over the loop but
    // you're supposed to call `fuzz` ad vitam aeternam
    loop {
        // The fuzz macro gives an arbitrary object (see `arbitrary crate`)
        // to a closure-like block of code.
        // For performance reasons, it is recommended that you use the native type
        // `&[u8]` when possible.
        // Here, this slice will contain a "random" quantity of "random" data.
        fuzz!(|s: &str| {
            let _ = leaf::config::from_string(s);
        });
    }
}
```
```bash
root@server:~/develop/leaf/leaf/fuzz# hexdump -C hfuzz_workspace/fuzz_target_1/SIGABRT.PC.7ffff7dbd00b.STACK.1a963bf0e4.CODE.-6.ADDR.0.INSTR.mov____0x108\(%rsp\)\,%rax.fuzz
00000000  5b 45 6e 76 5d 0a 6d 00  00 00 5d 20 3d c6 c6 c6  |[Env].m...] =...|
00000010  c6 c6 c6 c6 c6 c6 c6 c6  c6 c6 c6 c6 c6 c6 c6 c6  |................|
*
00000040  c6 c6 c6 c6 c6 c6 c6 c6  2c 00 00 00 20 2e 35 2e  |........,... .5.|
00000050  35 2e 35 0a 61 6c 77 61  79 73 2d 72 65 61 6c 2d  |5.5.always-real-|
00000060
```