### PR TITLE
support windows

### DIFF
--- a/leaf-cli/src/main.rs
+++ b/leaf-cli/src/main.rs
@@ -58,7 +58,7 @@ struct Args {
     test_outbound_timeout: u64,
 
     /// bound interface, explicitly sets the OUTBOUND_INTERFACE environment variable
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     #[argh(option, short = 'b')]
     boundif: Option<String>,
 
@@ -85,7 +85,7 @@ fn main() {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     if let Some(iface) = args.boundif {
         std::env::set_var("OUTBOUND_INTERFACE", iface);
     }

--- a/leaf-ffi/.cargo/config.toml
+++ b/leaf-ffi/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+rustflags = ["-Zshare-generics=off"]

--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -246,13 +246,15 @@ warp = { version = "0.3", default-features = false, optional = true }
 # Auto reload
 notify = { version = "6", optional = true }
 
+# TUN
+tun = { version = "0.7", features = ["async"], optional = true  }
+netstack-lwip = { git = "https://github.com/lanthora/netstack-lwip", rev = "2971587", optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+ipconfig = "0.3"
+
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
-
-# TUN
-[target.'cfg(any(target_os = "ios", target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
-tun = { git = "https://github.com/eycorsican/rust-tun.git", branch = "fork", features = ["async"], optional = true }
-netstack-lwip = { git = "https://github.com/eycorsican/netstack-lwip.git", rev = "b1f8596", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 pnet_datalink = { version = "0.34", package = "pnet_datalink", optional = true }

--- a/leaf/src/app/inbound/manager.rs
+++ b/leaf/src/app/inbound/manager.rs
@@ -36,28 +36,12 @@ use super::network_listener::NetworkInboundListener;
 #[cfg(feature = "inbound-cat")]
 use super::cat_listener::CatInboundListener;
 
-#[cfg(all(
-    feature = "inbound-tun",
-    any(
-        target_os = "ios",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "linux"
-    )
-))]
+#[cfg(feature = "inbound-tun")]
 use super::tun_listener::TunInboundListener;
 
 pub struct InboundManager {
     network_listeners: HashMap<String, NetworkInboundListener>,
-    #[cfg(all(
-        feature = "inbound-tun",
-        any(
-            target_os = "ios",
-            target_os = "android",
-            target_os = "macos",
-            target_os = "linux"
-        )
-    ))]
+    #[cfg(feature = "inbound-tun")]
     tun_listener: Option<TunInboundListener>,
     #[cfg(feature = "inbound-cat")]
     cat_listener: Option<CatInboundListener>,
@@ -245,15 +229,7 @@ impl InboundManager {
 
         let mut network_listeners: HashMap<String, NetworkInboundListener> = HashMap::new();
 
-        #[cfg(all(
-            feature = "inbound-tun",
-            any(
-                target_os = "ios",
-                target_os = "android",
-                target_os = "macos",
-                target_os = "linux"
-            )
-        ))]
+        #[cfg(feature = "inbound-tun")]
         let mut tun_listener: Option<TunInboundListener> = None;
 
         #[cfg(feature = "inbound-cat")]
@@ -264,15 +240,7 @@ impl InboundManager {
         for inbound in inbounds.iter() {
             let tag = String::from(&inbound.tag);
             match inbound.protocol.as_str() {
-                #[cfg(all(
-                    feature = "inbound-tun",
-                    any(
-                        target_os = "ios",
-                        target_os = "android",
-                        target_os = "macos",
-                        target_os = "linux"
-                    )
-                ))]
+                #[cfg(feature = "inbound-tun")]
                 "tun" => {
                     let listener = TunInboundListener {
                         inbound: inbound.clone(),
@@ -312,15 +280,7 @@ impl InboundManager {
 
         Ok(InboundManager {
             network_listeners,
-            #[cfg(all(
-                feature = "inbound-tun",
-                any(
-                    target_os = "ios",
-                    target_os = "android",
-                    target_os = "macos",
-                    target_os = "linux"
-                )
-            ))]
+            #[cfg(feature = "inbound-tun")]
             tun_listener,
             #[cfg(feature = "inbound-cat")]
             cat_listener,
@@ -336,15 +296,7 @@ impl InboundManager {
         Ok(runners)
     }
 
-    #[cfg(all(
-        feature = "inbound-tun",
-        any(
-            target_os = "ios",
-            target_os = "android",
-            target_os = "macos",
-            target_os = "linux"
-        )
-    ))]
+    #[cfg(feature = "inbound-tun")]
     pub fn get_tun_runner(&self) -> Result<Runner> {
         if let Some(listener) = &self.tun_listener {
             return listener.listen();
@@ -360,15 +312,7 @@ impl InboundManager {
         Err(anyhow!("no cat inbound"))
     }
 
-    #[cfg(all(
-        feature = "inbound-tun",
-        any(
-            target_os = "ios",
-            target_os = "android",
-            target_os = "macos",
-            target_os = "linux"
-        )
-    ))]
+    #[cfg(feature = "inbound-tun")]
     pub fn has_tun_listener(&self) -> bool {
         self.tun_listener.is_some()
     }

--- a/leaf/src/app/inbound/mod.rs
+++ b/leaf/src/app/inbound/mod.rs
@@ -1,14 +1,6 @@
 mod network_listener;
 
-#[cfg(all(
-    feature = "inbound-tun",
-    any(
-        target_os = "ios",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "linux"
-    )
-))]
+#[cfg(feature = "inbound-tun")]
 mod tun_listener;
 
 #[cfg(feature = "inbound-cat")]

--- a/leaf/src/app/mod.rs
+++ b/leaf/src/app/mod.rs
@@ -16,12 +16,6 @@ pub mod stat_manager;
 #[cfg(feature = "api")]
 pub mod api;
 
-#[cfg(any(
-    target_os = "ios",
-    target_os = "android",
-    target_os = "macos",
-    target_os = "linux"
-))]
 pub mod fake_dns;
 
 pub type SyncDnsClient = Arc<RwLock<dns_client::DnsClient>>;

--- a/leaf/src/lib.rs
+++ b/leaf/src/lib.rs
@@ -41,6 +41,10 @@ pub mod mobile;
 #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]
 mod sys;
 
+
+#[cfg(all(feature = "inbound-tun", target_os = "windows"))]
+mod winsys;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -450,15 +454,12 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
         }
     }
 
-    #[cfg(all(
-        feature = "inbound-tun",
-        any(
-            target_os = "ios",
-            target_os = "android",
-            target_os = "macos",
-            target_os = "linux"
-        )
-    ))]
+    #[cfg(all(feature = "inbound-tun", target_os = "windows"))]
+    {
+        std::env::set_var("OUTBOUND_INTERFACE", winsys::get_default_interface_ips());
+    }
+
+    #[cfg(feature = "inbound-tun")]
     if let Ok(r) = inbound_manager.get_tun_runner() {
         runners.push(r);
     }

--- a/leaf/src/option/mod.rs
+++ b/leaf/src/option/mod.rs
@@ -295,11 +295,11 @@ lazy_static! {
     };
 
     pub static ref DEFAULT_TUN_IPV4_ADDR: String = {
-        get_env_var_or("DEFAULT_TUN_IPV4_ADDR", "240.255.0.2".to_string())
+        get_env_var_or("DEFAULT_TUN_IPV4_ADDR", "192.168.233.2".to_string())
     };
 
     pub static ref DEFAULT_TUN_IPV4_GW: String = {
-        get_env_var_or("DEFAULT_TUN_IPV4_GW", "240.255.0.1".to_string())
+        get_env_var_or("DEFAULT_TUN_IPV4_GW", "192.168.233.1".to_string())
     };
 
     pub static ref DEFAULT_TUN_IPV4_MASK: String = {

--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -68,15 +68,7 @@ pub mod tls;
 pub mod trojan;
 #[cfg(feature = "outbound-tryall")]
 pub mod tryall;
-#[cfg(all(
-    feature = "inbound-tun",
-    any(
-        target_os = "ios",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "linux"
-    )
-))]
+#[cfg(feature = "inbound-tun")]
 pub mod tun;
 #[cfg(feature = "outbound-vmess")]
 pub mod vmess;

--- a/leaf/src/winsys.rs
+++ b/leaf/src/winsys.rs
@@ -1,0 +1,49 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+pub fn get_default_interface_ips() -> String {
+    let adapters = match ipconfig::get_adapters() {
+        Ok(adapters) => adapters,
+        Err(_) => return String::new(),
+    };
+
+    let candidate = adapters.iter()
+        .find(|a| !a.gateways().is_empty());
+
+    let adapter = match candidate {
+        Some(adapter) => adapter,
+        None => return String::new(),
+    };
+
+    let (mut ipv4, mut ipv6) = (None, None);
+
+    for ip in adapter.ip_addresses() {
+        match ip {
+            IpAddr::V4(v4) if !is_ipv4_link_local(v4) && ipv4.is_none() => {
+                ipv4 = Some(v4.to_string());
+            }
+            IpAddr::V6(v6) if !is_ipv6_link_local(v6) && ipv6.is_none() => {
+                ipv6 = Some(v6.to_string());
+            }
+            _ => {}
+        }
+
+        if ipv4.is_some() && ipv6.is_some() {
+            break;
+        }
+    }
+
+    match (ipv4, ipv6) {
+        (Some(v4), Some(v6)) => format!("{},{}", v4, v6),
+        (Some(v4), None) => v4,
+        (None, Some(v6)) => v6,
+        (None, None) => String::new(),
+    }
+}
+
+fn is_ipv4_link_local(addr: &Ipv4Addr) -> bool {
+    addr.octets()[0] == 169 && addr.octets()[1] == 254
+}
+
+fn is_ipv6_link_local(addr: &Ipv6Addr) -> bool {
+    (addr.segments()[0] & 0xffc0) == 0xfe80
+}


### PR DESCRIPTION
添加 Windows 支持

1. 其中 netstack-lwip 是我自己的项目，已经发了 [PR](https://github.com/eycorsican/netstack-lwip/pull/16)，需要合并后可以改成你的地址。
2. 修改了默认的地址和网关，原来的默认配置没有办法创建虚拟网卡，现在这个配置我在 Linux 上测试正常，不清楚这样修改会不会有什么其他的影响。