### PR TITLE
propagate tun/cat listener errors to the user

### DIFF
--- a/leaf/src/app/inbound/manager.rs
+++ b/leaf/src/app/inbound/manager.rs
@@ -297,19 +297,13 @@ impl InboundManager {
     }
 
     #[cfg(feature = "inbound-tun")]
-    pub fn get_tun_runner(&self) -> Result<Runner> {
-        if let Some(listener) = &self.tun_listener {
-            return listener.listen();
-        }
-        Err(anyhow!("no tun inbound"))
+    pub fn get_tun_runner(&self) -> Option<Result<Runner>> {
+        self.tun_listener.as_ref().map(TunInboundListener::listen)
     }
 
     #[cfg(feature = "inbound-cat")]
-    pub fn get_cat_runner(&self) -> Result<Runner> {
-        if let Some(listener) = &self.cat_listener {
-            return listener.listen();
-        }
-        Err(anyhow!("no cat inbound"))
+    pub fn get_cat_runner(&self) -> Option<Result<Runner>> {
+        self.cat_listener.as_ref().map(CatInboundListener::listen)
     }
 
     #[cfg(feature = "inbound-tun")]

--- a/leaf/src/lib.rs
+++ b/leaf/src/lib.rs
@@ -460,13 +460,13 @@ pub fn start(rt_id: RuntimeId, opts: StartOptions) -> Result<(), Error> {
     }
 
     #[cfg(feature = "inbound-tun")]
-    if let Ok(r) = inbound_manager.get_tun_runner() {
-        runners.push(r);
+    if let Some(r) = inbound_manager.get_tun_runner() {
+        runners.push(r.map_err(Error::Config)?);
     }
 
     #[cfg(feature = "inbound-cat")]
-    if let Ok(r) = inbound_manager.get_cat_runner() {
-        runners.push(r);
+    if let Some(r) = inbound_manager.get_cat_runner() {
+        runners.push(r.map_err(Error::Config)?);
     }
 
     #[cfg(all(feature = "inbound-tun", any(target_os = "macos", target_os = "linux")))]


### PR DESCRIPTION
# The issue
Failures happening during initializing tun inbound listener won't propagate back to the user.

ex: Using this `config.json`
```json
{
    "log": {
        "level": "debug"
    },
    "outbounds": [
        {
            "protocol": "socks",
            "settings": {
                "address": "192.168.1.100",
                "port": 1080
            },
            "tag": "socks_out"
        }
    ],
    "inbounds": [
        {
            "protocol": "tun",
            "settings": {
                "name": "tun1",
                "address": "198.18.0.1",
                "gateway": "198.18.0.1",
                "netmask": "255.254.0.0",
                "mtu": 1500
            },
            "tag": "tun_in"
        }
    ]
}
``` 
and running this comamnd:
```bash
leaf -c config.json
```
will lead to the program appears to be stuck without showing any errors even while using `debug` log level.
This will happen even though the tun device wasn't initialized properly because the executable doesn't have enough permissions or capabilities to configure a tun device:
```
start with options:
StartOptions {
    config: File(
        "config.json",
    ),
    auto_reload: false,
    runtime_opt: MultiThreadAuto(
        2097152,
    ),
}
2025-09-12T21:37:22.952452Z DEBUG leaf::app::outbound::manager: default handler [socks_out]
```

# The proposed solution

Differentiate between two cases:
* tun/cat listeners aren't being configured by the user
* tun/cat listeners failures during initialization

This will make it possible to propagate the errors to the user:
```
start with options:
StartOptions {
    config: File(
        "config.json",
    ),
    auto_reload: false,
    runtime_opt: MultiThreadAuto(
        2097152,
    ),
}
2025-09-12T21:37:22.952452Z DEBUG leaf::app::outbound::manager: default handler [socks_out]
start leaf failed: create tun failed: Operation not permitted (os error 1)
```