### PR TITLE
Optimize socket binding for lower memory usage on iOS

### DIFF
--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -164,13 +164,13 @@ trait BindSocket {
 
 impl BindSocket for TcpSocket {
     fn bind(&self, bind_addr: &SocketAddr) -> io::Result<()> {
-        self.bind(bind_addr.to_owned())
+        self.bind((*bind_addr).into())
     }
 }
 
 impl BindSocket for socket2::Socket {
     fn bind(&self, bind_addr: &SocketAddr) -> io::Result<()> {
-        self.bind(&bind_addr.to_owned().into())
+        self.bind(&(*bind_addr).into())
     }
 }
 


### PR DESCRIPTION
remove unnecessary SocketAddr cloning during bind operations.

This change reduces memory overhead in iOS, improving stability under strict memory limits.