### PR TITLE
fix(http-inbound): avoid duplicated EOH when rewriting absolute-form to origin-form

### DIFF
--- a/leaf/src/proxy/http/inbound/stream.rs
+++ b/leaf/src/proxy/http/inbound/stream.rs
@@ -162,6 +162,12 @@ impl HttpStream {
 
         match head.target_format {
             TargetFormat::Absolute => {
+                // drain() returns (before EOH, starting at EOH). To avoid duplicating
+                // the CRLFCRLF boundary when we rebuild headers below, drop the
+                // leading EOH from the remainder.
+                if rest_buf.starts_with(&EOH) {
+                    let _ = rest_buf.drain(..EOH.len());
+                }
                 let path_and_query = head
                     .uri
                     .path_and_query()


### PR DESCRIPTION
Summary
When the HTTP inbound forwards HTTP/1.x requests that arrive in absolute-form (e.g. "POST http://host/path HTTP/1.1"), it rewrites the request line to origin-form and serializes a new set of headers. It then appends the buffered remainder of the original request. The remainder, however, starts at the original End-Of-Headers (EOH, CRLFCRLF), so the resulting stream contains two consecutive CRLFCRLF boundaries.

Many servers are sensitive to this. In particular, when the client uses Transfer-Encoding: chunked or posts JSON, the extra empty line can shift the expected body boundary and lead to parsing errors upstream (e.g. JSON tokenization like invalid character ' ' in literal true).

Reproduction
- Configure an HTTP inbound (forward proxy) and route the target domain via direct.
- Send a POST JSON request through the HTTP proxy (absolute-form) to a backend that expects a normal origin-form request.
- Observe the upstream returns 400 (e.g. JSON parse error) when using the HTTP proxy inbound, while the same request succeeds when either:
  - bypassing the proxy (direct client connection), or
  - using the SOCKS5 inbound (pure TCP tunnel), or
  - using CONNECT/HTTPS (pure tunnel after 200 Connection established).

Root cause
- The inbound splits the incoming request at EOH (CRLFCRLF) and returns (head_without_eoh, remainder_starting_from_eoh).
- We serialize a new request line and headers and, as per HTTP/1.x, terminate them with CRLFCRLF.
- We then append the remainder which starts with EOH again.
- Result: duplicated header terminator (two consecutive CRLFCRLF) before the body.

Fix
- Strip a leading EOH from the buffered remainder before concatenating with the freshly serialized headers, ensuring exactly one CRLFCRLF between headers and body.

Patch
- File: leaf/src/proxy/http/inbound/stream.rs
- Location: HttpStream::sniff(), Absolute branch
- Change:
  ```rust
  // drain() returns (before EOH, starting at EOH). To avoid duplicating
  // the CRLFCRLF boundary when we rebuild headers below, drop the
  // leading EOH from the remainder.
  if rest_buf.starts_with(&EOH) {
      let _ = rest_buf.drain(..EOH.len());
  }
  ```

Impact
- Minimal, contained to the Absolute target format path of the HTTP inbound.
- CONNECT/HTTPS and SOCKS inbounds are unaffected (they are pure tunnels).
- No behavioral change for requests without a body; fixes malformed framing for requests with a body (e.g., chunked or JSON).