### PR TITLE
fix(config): ensure tun settings are applied when fd is -1

### DIFF
--- a/leaf/src/config/common.rs
+++ b/leaf/src/config/common.rs
@@ -508,8 +508,9 @@ pub fn to_internal(mut config: Config) -> Result<internal::Config> {
                             settings.fake_dns_include = fake_dns_include;
                         }
 
-                        if let Some(ext_fd) = ext_settings.fd {
-                            settings.fd = ext_fd;
+                        let fd = ext_settings.fd.unwrap_or(-1);
+                        if fd >= 0 {
+                            settings.fd = fd;
                         } else {
                             settings.fd = -1; // disable fd option
                             if let Some(ext_name) = &ext_settings.name {


### PR DESCRIPTION
## Problem
When using the INI configuration format (handled in [leaf/src/config/conf/config.rs](cci:7://file:///leaf/src/config/conf/config.rs:0:0-0:0)), setting `tun = auto` or manually configuring a TUN interface results in the internal `tun_fd` being parsed as `Some(-1)`.
```rust
// config.rs 行 814-818 (tun-auto 逻辑)
} else if let Some(auto) = ext_general.tun_auto {
    if auto {
        settings.auto = Some(true);
        settings.fd = Some(-1); // <--- 这里显式设置了 fd 为 -1
    }
}
// config.rs 行 819-826 (手动 tun 逻辑)
} else if let Some(ext_tun) = &ext_general.tun {
    settings.fd = Some(-1); // <--- 这里也显式设置了 fd 为 -1
    settings.name = ext_tun.name.clone();
    // ...
}
```

In the downstream conversion logic (`leaf/src/config/common.rs`), the code previously used:
```rust
if let Some(ext_fd) = ext_settings.fd {
    settings.fd = ext_fd;
} else {
    // Logic to handle name, auto, address, etc.
}

Since Some(-1) satisfies the if condition, the code would assign the invalid FD and skip the else block entirely. This caused tun = auto and other standard TUN configurations in INI files to be ignored, as they are defined within that skipped block.

Solution
I have updated the logic in leaf/src/config/common.rs to explicitly check if the file descriptor is valid:
```rust
let fd = ext_settings.fd.unwrap_or(-1);
if fd >= 0 {
    settings.fd = fd;
} else {
    settings.fd = -1;
    // Fallback: configure via name/auto/address
}
```
Now, if fd is -1 (which is the default from the config parser), the code correctly falls through to apply the name, auto, and address settings as intended.

