### PR TITLE
fix: resolve compilation warnings with latest stable toolchain

### DIFF
--- a/leaf/src/common/cmd_linux.rs
+++ b/leaf/src/common/cmd_linux.rs
@@ -113,7 +113,7 @@ pub fn get_default_interface() -> Result<String> {
 pub fn add_interface_ipv4_address(
     name: &str,
     addr: Ipv4Addr,
-    gw: Ipv4Addr,
+    _gw: Ipv4Addr,
     mask: Ipv4Addr,
 ) -> Result<()> {
     Command::new("ip")

--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -191,7 +191,7 @@ impl TcpListener {
     pub async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         let (stream, addr) = self.inner.accept().await?;
         apply_socket_opts(&stream)?;
-        stream.set_linger(Some(Duration::ZERO))?;
+        SockRef::from(&stream).set_linger(Some(Duration::ZERO))?;
         Ok((stream, addr))
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes 2 compilation warnings that appear when building with the **latest stable Rust toolchain** and resolving the latest compatible dependencies (no `Cargo.lock` is committed in this repo).

## Changes

### 1. Replace deprecated `TcpStream::set_linger()` (`leaf/src/proxy/mod.rs`)

```diff
- stream.set_linger(Some(Duration::ZERO))?;
+ SockRef::from(&stream).set_linger(Some(Duration::ZERO))?;
```

**Why:** Tokio deprecated `TcpStream::set_linger()` starting from **v1.37** because `SO_LINGER` causes the socket to block the calling thread on `drop()`. Since the project specifies `tokio = { version = "1", ... }` without a lockfile, any fresh build today resolves tokio ≥ 1.37 and triggers this warning. The replacement uses `socket2::SockRef`, which is already a dependency of this project. The runtime behavior is **identical**.

**Reference:** [tokio-rs/tokio#5765](https://github.com/tokio-rs/tokio/issues/5765)

### 2. Prefix unused parameter `gw` with underscore (`leaf/src/common/cmd_linux.rs`)

```diff
- gw: Ipv4Addr,
+ _gw: Ipv4Addr,
```

**Why:** The `add_interface_ipv4_address()` function on Linux uses `ip addr add`, which does not accept a gateway argument (gateways are set separately via `ip route add`). The `gw` parameter exists for API parity with the macOS implementation but is correctly unused on Linux. Prefixing with `_` makes this intent explicit and silences the `unused_variables` warning. This warning has existed since the function was first written but may have been overlooked.

## Impact

- **Zero behavioral change** — both fixes only affect compilation, not runtime logic
- **No API breaking changes** — function signatures remain identical
- Enables **warning-free builds** for anyone building the project today