### PR TITLE
build: enable IP_BOUND_IF outbound binding on iOS

### DIFF
--- a/leaf/Cargo.toml
+++ b/leaf/Cargo.toml
@@ -282,6 +282,9 @@ jni = "0.21"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 pnet_datalink = { version = "0.34", package = "pnet_datalink", optional = true }
+
+# libc is also required on iOS (for IP_BOUND_IF outbound binding)
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))'.dependencies]
 libc = "0.2"
 
 # Used in mobile logger

--- a/leaf/src/proxy/mod.rs
+++ b/leaf/src/proxy/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 use std::ffi::CString;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
@@ -18,7 +18,7 @@ use tracing::debug;
 
 #[cfg(unix)]
 use std::os::unix::io::AsFd;
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, AsSocket};
@@ -161,12 +161,12 @@ async fn protect_socket(fd: RawFd) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux"))]
 trait BindSocket: AsFd {
     fn bind(&self, bind_addr: &SocketAddr) -> io::Result<()>;
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
 trait BindSocket {
     fn bind(&self, bind_addr: &SocketAddr) -> io::Result<()>;
 }
@@ -227,7 +227,7 @@ async fn bind_socket<T: BindSocket>(socket: &T, indicator: &SocketAddr) -> io::R
     for bind in option::OUTBOUND_BINDS.iter() {
         match bind {
             OutboundBind::Interface(iface) => {
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "ios"))]
                 unsafe {
                     let ifa = CString::new(iface.as_bytes()).unwrap();
                     let ifidx: libc::c_uint = libc::if_nametoindex(ifa.as_ptr());
@@ -276,7 +276,7 @@ async fn bind_socket<T: BindSocket>(socket: &T, indicator: &SocketAddr) -> io::R
                     debug!("socket bind {}", iface);
                     return Ok(());
                 }
-                #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+                #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
                 {
                     let _ = iface;
                     return Err(io::Error::new(


### PR DESCRIPTION
Upstream's #[cfg(target_os = "macos")] gates on the IP_BOUND_IF setsockopt path (and supporting imports/traits) exclude iOS, even though iOS shares the Darwin kernel and supports IP_BOUND_IF identically. iOS targets fall through to the catch-all and return "binding to interface is not supported on this platform" at runtime.

Extend the cfg sets to include target_os = "ios" in:
  - CString / AsRawFd imports
  - trait BindSocket (and its fallback definition)
  - the setsockopt(IP_BOUND_IF) call site
  - the unreachable error branch

Also add libc as a dependency for the ios target (previously only gated for macos + linux).

Verified on iPhone via NEPacketTunnelProvider: OUTBOUND_INTERFACE= pdp_ip0 setenv before leaf_run, leaf logs "socket bind pdp_ip0" and outbound TCP/UDP correctly egress over the cellular interface without going back into the tun.