### PR TITLE
Add optional VLESS flow parameter

### DIFF
--- a/leaf/src/app/outbound/manager.rs
+++ b/leaf/src/app/outbound/manager.rs
@@ -274,6 +274,7 @@ impl OutboundManager {
                         address: settings.address.clone(),
                         port: settings.port as u16,
                         uuid: settings.uuid.clone(),
+                        flow: settings.flow.clone(),
                     });
                     let datagram = Arc::new(vless::outbound::DatagramHandler {
                         address: settings.address.clone(),

--- a/leaf/src/config/common.rs
+++ b/leaf/src/config/common.rs
@@ -186,6 +186,9 @@ pub struct VlessOutboundSettings {
     pub address: Option<String>,
     pub port: Option<u16>,
     pub uuid: Option<String>,
+    /// VLESS flow, e.g. "xtls-rprx-vision". Empty/absent means no flow,
+    /// which is required for transports like WebSocket.
+    pub flow: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1132,6 +1135,9 @@ pub fn to_internal(mut config: Config) -> Result<internal::Config> {
                         }
                         if let Some(ext_uuid) = &ext_settings.uuid {
                             settings.uuid = ext_uuid.clone();
+                        }
+                        if let Some(ext_flow) = &ext_settings.flow {
+                            settings.flow = ext_flow.clone();
                         }
                         let settings = settings.write_to_bytes().unwrap();
                         outbound.settings = settings;

--- a/leaf/src/config/conf/config.rs
+++ b/leaf/src/config/conf/config.rs
@@ -1226,6 +1226,7 @@ pub fn to_common(conf: &Config) -> Result<common::Config> {
                             .uuid
                             .clone()
                             .or_else(|| ext_proxy.password.clone()), // prioritize uuid, then password
+                        flow: None,
                     };
 
                     let mut next_tag = ext_proxy.tag.clone();

--- a/leaf/src/config/internal/config.proto
+++ b/leaf/src/config/internal/config.proto
@@ -209,6 +209,7 @@ message VlessOutboundSettings {
     string address = 1;
     uint32 port = 2;
     string uuid = 3;
+    string flow = 4;
 }
 
 message RealityOutboundSettings {

--- a/leaf/src/config/internal/config.rs
+++ b/leaf/src/config/internal/config.rs
@@ -3725,6 +3725,8 @@ pub struct VlessOutboundSettings {
     pub port: u32,
     // @@protoc_insertion_point(field:VlessOutboundSettings.uuid)
     pub uuid: ::std::string::String,
+    // @@protoc_insertion_point(field:VlessOutboundSettings.flow)
+    pub flow: ::std::string::String,
     // special fields
     // @@protoc_insertion_point(special_field:VlessOutboundSettings.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -3761,6 +3763,9 @@ impl ::protobuf::Message for VlessOutboundSettings {
                 26 => {
                     self.uuid = is.read_string()?;
                 },
+                34 => {
+                    self.flow = is.read_string()?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -3782,6 +3787,9 @@ impl ::protobuf::Message for VlessOutboundSettings {
         if !self.uuid.is_empty() {
             my_size += ::protobuf::rt::string_size(3, &self.uuid);
         }
+        if !self.flow.is_empty() {
+            my_size += ::protobuf::rt::string_size(4, &self.flow);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -3796,6 +3804,9 @@ impl ::protobuf::Message for VlessOutboundSettings {
         }
         if !self.uuid.is_empty() {
             os.write_string(3, &self.uuid)?;
+        }
+        if !self.flow.is_empty() {
+            os.write_string(4, &self.flow)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -3817,6 +3828,7 @@ impl ::protobuf::Message for VlessOutboundSettings {
         self.address.clear();
         self.port = 0;
         self.uuid.clear();
+        self.flow.clear();
         self.special_fields.clear();
     }
 
@@ -3825,6 +3837,7 @@ impl ::protobuf::Message for VlessOutboundSettings {
             address: ::std::string::String::new(),
             port: 0,
             uuid: ::std::string::String::new(),
+            flow: ::std::string::String::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance

--- a/leaf/src/proxy/vless/outbound/stream.rs
+++ b/leaf/src/proxy/vless/outbound/stream.rs
@@ -11,6 +11,8 @@ pub struct Handler {
     pub address: String,
     pub port: u16,
     pub uuid: String,
+    /// VLESS flow. Empty means no flow (required for ws/grpc transports).
+    pub flow: String,
 }
 
 #[async_trait]
@@ -43,15 +45,21 @@ impl OutboundStreamHandler for Handler {
         let host = sess.destination.host();
         let port = sess.destination.port();
 
-        let header = build_vless_tcp_header(&uuid_bytes, &host, port, addr_type);
+        let header = build_vless_tcp_header(&uuid_bytes, &host, port, addr_type, &self.flow);
 
         let mut stream = stream.ok_or_else(|| io::Error::other("invalid input"))?;
         stream.write_all(&header).await?;
 
+        let vision = self.flow == "xtls-rprx-vision";
         Ok(Box::new(VlessStream::new(
             stream,
             uuid_bytes,
-            Some(sess.vision_read_raw.clone()),
+            if vision {
+                Some(sess.vision_read_raw.clone())
+            } else {
+                None
+            },
+            vision,
         )))
     }
 }

--- a/leaf/src/proxy/vless/stream.rs
+++ b/leaf/src/proxy/vless/stream.rs
@@ -3,17 +3,24 @@ pub fn build_vless_tcp_header(
     dst_addr: &str,
     dst_port: u16,
     addr_type: u8,
+    flow: &str,
 ) -> Vec<u8> {
     let mut vless_header = vec![];
     vless_header.push(0x00); // Version
     vless_header.extend_from_slice(uuid_bytes);
 
-    // TCP - Use Vision Flow
-    let flow_str = b"xtls-rprx-vision";
-    vless_header.push(18); // Extensions length
-    vless_header.push(0x0a); // Protobuf Field 1, Type Length-Delimited
-    vless_header.push(16); // String length
-    vless_header.extend_from_slice(flow_str);
+    // Addons: a non-empty flow (e.g. "xtls-rprx-vision") is encoded as a
+    // protobuf message in field 1; an empty flow means no addons, which is
+    // what transports like WebSocket and gRPC require.
+    if flow.is_empty() {
+        vless_header.push(0x00); // Addons length = 0
+    } else {
+        let flow_bytes = flow.as_bytes();
+        vless_header.push((flow_bytes.len() + 2) as u8); // Addons length
+        vless_header.push(0x0a); // Protobuf Field 1, Type Length-Delimited
+        vless_header.push(flow_bytes.len() as u8); // String length
+        vless_header.extend_from_slice(flow_bytes);
+    }
     vless_header.push(0x01); // Command: TCP
 
     vless_header.push((dst_port >> 8) as u8);
@@ -51,7 +58,7 @@ pub struct VisionParser {
 }
 
 impl VisionParser {
-    pub fn new(uuid_bytes: [u8; 16]) -> Self {
+    pub fn new(uuid_bytes: [u8; 16], vision_enabled: bool) -> Self {
         Self {
             uuid_bytes,
             v_remaining_cmd: -1,
@@ -60,8 +67,10 @@ impl VisionParser {
             v_current_cmd: 0,
             v_buffer: Vec::new(),
             vless_response_header_parsed: false,
-            v_direct_copy_rx: false,
-            v_vision_done: false,
+            // With no flow, there is no Vision framing: once the 2-byte VLESS
+            // response header is consumed, the rest is passed through verbatim.
+            v_direct_copy_rx: !vision_enabled,
+            v_vision_done: !vision_enabled,
         }
     }
 
@@ -203,10 +212,15 @@ pub struct VlessStream<S> {
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin> VlessStream<S> {
-    pub fn new(stream: S, uuid_bytes: [u8; 16], shared_read_raw: Option<Arc<AtomicBool>>) -> Self {
+    pub fn new(
+        stream: S,
+        uuid_bytes: [u8; 16],
+        shared_read_raw: Option<Arc<AtomicBool>>,
+        vision_enabled: bool,
+    ) -> Self {
         Self {
             stream,
-            vision_parser: VisionParser::new(uuid_bytes),
+            vision_parser: VisionParser::new(uuid_bytes, vision_enabled),
             plaintext_buffer: Vec::new(),
             is_direct_copy: false,
             shared_read_raw,


### PR DESCRIPTION
VLESS outbounds always sent the `xtls-rprx-vision` flow in the request header and wrapped the stream in the Vision parser. The flow was hardcoded, with no way to turn it off.

Vision operates on the raw TLS stream and only works with the plain TCP transport — it cannot be used with WebSocket, gRPC or HTTP/2 (see [Project X docs](https://xtls.github.io/en/config/transport.html)). With the flow forced on, vless outbounds over those transports could not work at all.

Since enabling Vision is a deployment choice, it is better left to the user. This adds a `flow` field to `VlessOutboundSettings`:

- empty or absent → no addons are sent (addon length `0x00`) and the Vision wrapper is disabled — works with any transport;
- `"xtls-rprx-vision"` → restores the previous behaviour.

The default is empty (no flow).